### PR TITLE
Split posterior precision update into two branches

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -89,7 +89,7 @@ Prediction error steps
 Compute the value and volatility prediction errors of a given node. The prediction error can only be computed after the posterior update (or observation) of a given node.
 
 Binary state nodes
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. currentmodule:: pyhgf.updates.prediction_error.binary
 
@@ -100,7 +100,7 @@ Binary state nodes
     binary_finite_state_node_prediction_error
 
 Categorical state nodes
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 .. currentmodule:: pyhgf.updates.prediction_error.categorical
 
@@ -110,7 +110,7 @@ Categorical state nodes
     categorical_state_prediction_error
 
 Continuous state nodes
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 .. currentmodule:: pyhgf.updates.prediction_error.continuous
 
@@ -122,7 +122,7 @@ Continuous state nodes
     continuous_node_prediction_error
 
 Dirichlet state nodes
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 .. currentmodule:: pyhgf.updates.prediction_error.dirichlet
 
@@ -137,7 +137,7 @@ Dirichlet state nodes
     clusters_likelihood
 
 Exponential family
-^^^^^^^^^^^^^^^^^^
+------------------
 
 .. currentmodule:: pyhgf.updates.prediction_error.exponential
 

--- a/pyhgf/updates/posterior/continuous/__init__.py
+++ b/pyhgf/updates/posterior/continuous/__init__.py
@@ -3,6 +3,5 @@ from .continuous_node_posterior_update_ehgf import continuous_node_posterior_upd
 
 __all__ = [
     "continuous_node_posterior_update_ehgf",
-    "continuous_node_posterior_update_unbounded",
     "continuous_node_posterior_update",
 ]


### PR DESCRIPTION
This PR splits the posterior update of the precision of a continuous node into two branches, depending on whether the children have observed at least one value or not. When no value is observed, the precision should be updated differently (slowly decreasing as a function of time). Here, we start the update by testing this, therefore avoiding the evaluation of one of the two branches, resulting in a performance gain.