### PR TITLE
fix the insert_nodes function for multiple parents/children

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,7 +28,7 @@ jobs:
       run: >-
         poetry build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
 
       # Step 13: Upload benchmark artifact
       - name: Upload baseline benchmark
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: baseline-benchmark
           path: .benchmarks/new_benchmark.json

--- a/pyhgf/model/add_nodes.py
+++ b/pyhgf/model/add_nodes.py
@@ -411,34 +411,38 @@ def insert_nodes(
         # Update the edges of the parents and children accordingly
         # --------------------------------------------------------
         if value_parents[0] is not None:
-            network.add_edges(
-                kind="value",
-                parent_idxs=value_parents[0],
-                children_idxs=node_idx,
-                coupling_strengths=value_parents[1],  # type: ignore
-            )
+            for idx, cpl in zip(value_parents[0], value_parents[1]):
+                network.add_edges(
+                    kind="value",
+                    parent_idxs=idx,
+                    children_idxs=node_idx,
+                    coupling_strengths=cpl,  # type: ignore
+                )
         if value_children[0] is not None:
-            network.add_edges(
-                kind="value",
-                parent_idxs=node_idx,
-                children_idxs=value_children[0],
-                coupling_strengths=value_children[1],  # type: ignore
-                coupling_fn=coupling_fn,
-            )
+            for idx, cpl in zip(value_children[0], value_children[1]):
+                network.add_edges(
+                    kind="value",
+                    parent_idxs=node_idx,
+                    children_idxs=idx,
+                    coupling_strengths=cpl,  # type: ignore
+                    coupling_fn=coupling_fn,
+                )
         if volatility_children[0] is not None:
-            network.add_edges(
-                kind="volatility",
-                parent_idxs=node_idx,
-                children_idxs=volatility_children[0],
-                coupling_strengths=volatility_children[1],  # type: ignore
-            )
+            for idx, cpl in zip(volatility_children[0], volatility_children[1]):
+                network.add_edges(
+                    kind="volatility",
+                    parent_idxs=node_idx,
+                    children_idxs=idx,
+                    coupling_strengths=cpl,  # type: ignore
+                )
         if volatility_parents[0] is not None:
-            network.add_edges(
-                kind="volatility",
-                parent_idxs=volatility_parents[0],
-                children_idxs=node_idx,
-                coupling_strengths=volatility_parents[1],  # type: ignore
-            )
+            for idx, cpl in zip(volatility_parents[0], volatility_parents[1]):
+                network.add_edges(
+                    kind="volatility",
+                    parent_idxs=idx,
+                    children_idxs=node_idx,
+                    coupling_strengths=cpl,  # type: ignore
+                )
 
         network.n_nodes += 1
 

--- a/pyhgf/model/network.py
+++ b/pyhgf/model/network.py
@@ -418,7 +418,10 @@ class Network:
         # into tuples of indexes and coupling strength
         value_parents, volatility_parents, value_children, volatility_children = (
             get_couplings(
-                value_parents, volatility_parents, value_children, volatility_children
+                value_parents=value_parents,
+                volatility_parents=volatility_parents,
+                value_children=value_children,
+                volatility_children=volatility_children,
             )
         )
 

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -30,7 +30,7 @@ def test_categorical_state_node():
     categorical_hgf.to_pandas()
 
     assert jnp.isclose(
-        categorical_hgf.node_trajectories[0]["kl_divergence"].sum(), 1.2844281
+        categorical_hgf.node_trajectories[0]["kl_divergence"].sum(), 1.2846234
     )
     assert jnp.isclose(
         categorical_hgf.node_trajectories[0]["surprise"].sum(), 12.514427

--- a/tests/test_categorical.py
+++ b/tests/test_categorical.py
@@ -23,6 +23,51 @@ def test_categorical_state_node():
         },
     )
 
+    # sanity check on the network structure
+    # ensure that the number of parents and children match the number of coupling values
+    for i in range(len(categorical_hgf.edges)):
+        if categorical_hgf.edges[i].node_type == 2:
+            # value parents ------------------------------------------------------------
+            if categorical_hgf.edges[i].value_parents:
+                assert len(categorical_hgf.edges[i].value_parents) == len(
+                    categorical_hgf.attributes[i]["value_coupling_parents"]
+                )
+            else:
+                assert (categorical_hgf.edges[i].value_parents is None) and (
+                    categorical_hgf.attributes[i]["value_coupling_parents"] is None
+                )
+
+            # value children -----------------------------------------------------------
+            if categorical_hgf.edges[i].value_children:
+                assert len(categorical_hgf.edges[i].value_children) == len(
+                    categorical_hgf.attributes[i]["value_coupling_children"]
+                )
+            else:
+                assert (categorical_hgf.edges[i].value_children is None) and (
+                    categorical_hgf.attributes[i]["value_coupling_children"] is None
+                )
+
+            # volatility parents -------------------------------------------------------
+            if categorical_hgf.edges[i].volatility_parents:
+                assert len(categorical_hgf.edges[i].volatility_parents) == len(
+                    categorical_hgf.attributes[i]["volatility_coupling_parents"]
+                )
+            else:
+                assert (categorical_hgf.edges[i].volatility_parents is None) and (
+                    categorical_hgf.attributes[i]["volatility_coupling_parents"] is None
+                )
+
+            # volatility children ------------------------------------------------------
+            if categorical_hgf.edges[i].volatility_children:
+                assert len(categorical_hgf.edges[i].volatility_children) == len(
+                    categorical_hgf.attributes[i]["volatility_coupling_children"]
+                )
+            else:
+                assert (categorical_hgf.edges[i].volatility_children is None) and (
+                    categorical_hgf.attributes[i]["volatility_coupling_children"]
+                    is None
+                )
+
     # fitting the model forwards
     categorical_hgf.input_data(input_data=input_data)
 
@@ -33,5 +78,5 @@ def test_categorical_state_node():
         categorical_hgf.node_trajectories[0]["kl_divergence"].sum(), 1.2846234
     )
     assert jnp.isclose(
-        categorical_hgf.node_trajectories[0]["surprise"].sum(), 12.514427
+        categorical_hgf.node_trajectories[0]["surprise"].sum(), 12.514741
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,6 +29,8 @@ def test_network():
         .add_nodes(volatility_children=[2, 3])
         .add_nodes(volatility_children=2)
         .add_nodes(volatility_children=7)
+        .add_nodes(value_parents=8)
+        .add_nodes(volatility_parents=9)
     )
 
     # sanity check on the network structure

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,6 +31,50 @@ def test_network():
         .add_nodes(volatility_children=7)
     )
 
+    # sanity check on the network structure
+    # ensure that the number of parents and children match the number of coupling values
+    for i in range(len(custom_hgf.edges)):
+        if custom_hgf.edges[i].node_type == 2:
+            # value parents ------------------------------------------------------------
+            if custom_hgf.edges[i].value_parents:
+                assert len(custom_hgf.edges[i].value_parents) == len(
+                    custom_hgf.attributes[i]["value_coupling_parents"]
+                )
+            else:
+                assert (custom_hgf.edges[i].value_parents is None) and (
+                    custom_hgf.attributes[i]["value_coupling_parents"] is None
+                )
+
+            # value children -----------------------------------------------------------
+            if custom_hgf.edges[i].value_children:
+                assert len(custom_hgf.edges[i].value_children) == len(
+                    custom_hgf.attributes[i]["value_coupling_children"]
+                )
+            else:
+                assert (custom_hgf.edges[i].value_children is None) and (
+                    custom_hgf.attributes[i]["value_coupling_children"] is None
+                )
+
+            # volatility parents -------------------------------------------------------
+            if custom_hgf.edges[i].volatility_parents:
+                assert len(custom_hgf.edges[i].volatility_parents) == len(
+                    custom_hgf.attributes[i]["volatility_coupling_parents"]
+                )
+            else:
+                assert (custom_hgf.edges[i].volatility_parents is None) and (
+                    custom_hgf.attributes[i]["volatility_coupling_parents"] is None
+                )
+
+            # volatility children ------------------------------------------------------
+            if custom_hgf.edges[i].volatility_children:
+                assert len(custom_hgf.edges[i].volatility_children) == len(
+                    custom_hgf.attributes[i]["volatility_coupling_children"]
+                )
+            else:
+                assert (custom_hgf.edges[i].volatility_children is None) and (
+                    custom_hgf.attributes[i]["volatility_coupling_children"] is None
+                )
+
     custom_hgf.create_belief_propagation_fn(overwrite=False)
     custom_hgf.create_belief_propagation_fn(overwrite=True)
 


### PR DESCRIPTION
The function was not correctly propagating the coupling strength vectors to parents/children.