### PR TITLE
use jax.nn.sigmoid by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target*
 *DS_Store
 .benchmarks/
 pyhgf/*.so
+Makefile
+uv.lock

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -309,7 +309,6 @@ Math functions and probability densities.
     Normal
     gaussian_predictive_distribution
     gaussian_density
-    sigmoid
     binary_surprise
     gaussian_surprise
     dirichlet_kullback_leibler

--- a/pyhgf/math.py
+++ b/pyhgf/math.py
@@ -191,15 +191,6 @@ def gaussian_density(x: ArrayLike, mean: ArrayLike, precision: ArrayLike) -> Arr
     return precision / jnp.sqrt(2 * jnp.pi) * jnp.exp(-precision / 2 * (x - mean) ** 2)
 
 
-def sigmoid(
-    x: Union[ArrayLike, float],
-    lower_bound: Union[ArrayLike, float] = 0.0,
-    upper_bound: Union[ArrayLike, float] = 1.0,
-) -> ArrayLike:
-    """Logistic sigmoid function."""
-    return (upper_bound - lower_bound) / (1 + jnp.exp(-x)) + lower_bound
-
-
 def binary_surprise(
     x: Union[float, ArrayLike], expected_mean: Union[float, ArrayLike]
 ) -> ArrayLike:

--- a/pyhgf/updates/prediction/binary.py
+++ b/pyhgf/updates/prediction/binary.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from jax import jit
 
-from pyhgf.math import sigmoid
+from jax.nn import sigmoid
 from pyhgf.typing import Edges
 
 

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -3,7 +3,7 @@
 import jax.numpy as jnp
 
 from pyhgf import load_data
-from pyhgf.math import binary_surprise, gaussian_density, sigmoid
+from pyhgf.math import binary_surprise, gaussian_density
 from pyhgf.model import Network
 from pyhgf.utils import beliefs_propagation
 
@@ -16,11 +16,6 @@ def test_gaussian_density():
         precision=jnp.array([1.0, 1.0]),
     )
     assert jnp.all(jnp.isclose(surprise, 0.24197073))
-
-
-def test_sgm():
-    """Test the sigmoid function."""
-    assert jnp.all(jnp.isclose(sigmoid(jnp.array([0.3, 0.3])), 0.5744425))
 
 
 def test_binary_surprise():


### PR DESCRIPTION
Remove the pyhgf sigmoid implementation to ensure better support and numerical stability.