### PR TITLE
Fix the vectorised prediction variance and the weight initialisation

### DIFF
--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -41,6 +41,7 @@ from pyhgf.utils.vectorized_belief_propagation import (
     update_sweep,
 )
 from pyhgf.utils.weight_initialisation import (
+    _init_matrix,
     he_init,
     orthogonal_init,
     sparse_init,
@@ -706,15 +707,27 @@ class DeepNetwork:
                 # byte-parity with the unrolled path; the underlying "all
                 # layers identical at init" pattern is a separate concern).
                 n_slices, n_children, n_parents = elem.weights_in.shape
-                flat = init_fn(n_parents, n_children, seed=seed, **kwargs)
-                per_slice = jnp.array(flat.reshape(n_children, n_parents))
+                per_slice = _init_matrix(
+                    init_fn,
+                    n_children,
+                    n_parents,
+                    elem.add_constant_input,
+                    seed,
+                    kwargs,
+                )
                 new_weights = jnp.broadcast_to(
                     per_slice, (n_slices, n_children, n_parents)
                 )
             else:
                 n_children, n_parents = elem.weights_in.shape
-                flat = init_fn(n_parents, n_children, seed=seed, **kwargs)
-                new_weights = jnp.array(flat.reshape(elem.weights_in.shape))
+                new_weights = _init_matrix(
+                    init_fn,
+                    n_children,
+                    n_parents,
+                    elem.add_constant_input,
+                    seed,
+                    kwargs,
+                )
             new_elements[i] = dataclasses.replace(elem, weights_in=new_weights)
 
         self.state = dataclasses.replace(self.state, layers=tuple(new_elements))

--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -174,11 +174,11 @@ def vectorized_layer_prediction(
         # The constant node never varies: zero derivative, infinite precision.
         parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
         g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
-    # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ ((t · g')² / π): the
+    # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ (g'² / π): the
     # weight-dependent factor is a constant matrix, so the per-node sum is a
-    # matrix product with a per-node vector — no weight-matrix-sized
-    # intermediate, which matters when this function is vmapped over a batch.
-    per_parent_variance = (time_step * g_prime) ** 2 / parent_precision
+    # matrix product with a per-node vector.
+    # The variance carries no time step (deviation from the Network class).
+    per_parent_variance = g_prime**2 / parent_precision
     value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
 
     # Conditional predicted precision π̂_a — the precision of x_a given a specific

--- a/pyhgf/utils/weight_initialisation.py
+++ b/pyhgf/utils/weight_initialisation.py
@@ -13,12 +13,16 @@ Available strategies
 * **He (Kaiming)** — :func:`he_init`
 * **Orthogonal** — :func:`orthogonal_init`
 * **Sparse** — :func:`sparse_init`
+
+:func:`_init_matrix` assembles one weight matrix from a strategy, keeping the bias
+column out of the statistics.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Callable, Optional
 
+import jax.numpy as jnp
 import numpy as np
 
 
@@ -89,9 +93,14 @@ def orthogonal_init(
 ) -> np.ndarray:
     """Orthogonal initialisation.
 
-    Generates a random matrix, computes its SVD, and returns the
-    (semi-)orthogonal factor scaled by *gain*.  This preserves gradient
-    norms during backpropagation.
+    Takes the orthogonal factor of a random matrix's SVD, scaled by *gain*. Every
+    singular value is then exactly one, so the layer applies the *same* gain to every
+    direction of its input rather than stretching some and squashing others. The returned
+    vector is row-major over an ``(n_children, n_parents)`` matrix, which is the shape
+    callers reshape it to. Orthogonality means ``W.T @ W = I`` when there are at least as
+    many children as parents, so every input direction keeps its length. With fewer children
+    than parents the layer is a projection and no matrix can preserve every direction; the
+    best available is ``W @ W.T = I``, which preserves length within the row space.
 
     Parameters
     ----------
@@ -100,26 +109,29 @@ def orthogonal_init(
     n_children :
         Number of child (output) nodes — fan-out.
     gain :
-        Multiplicative scaling factor (default 1.0).
+        Multiplicative scaling factor (default 1.0). A norm-preserving nonlinearity
+        would need none, but the ReLU family roughly halves the variance passing
+        through it, so ``gain=sqrt(2)`` is the usual compensation.
     seed :
         Optional random seed for reproducibility.
 
     Returns
     -------
     numpy.ndarray
-        Weight vector of length ``n_parents * n_children``.
+        Weight vector of length ``n_parents * n_children``, row-major over an
+        ``(n_children, n_parents)`` matrix.
     """
     rng = np.random.default_rng(seed)
-    # Always create a tall-or-square matrix so full_matrices=False gives
-    # the right number of orthogonal columns.
-    if n_parents >= n_children:
-        a = rng.standard_normal((n_parents, n_children))
-        u, _, _ = np.linalg.svd(a, full_matrices=False)
-        q = u  # (n_parents, n_children)
-    else:
+    # Draw tall-or-square so ``full_matrices=False`` yields orthonormal columns, then
+    # orient the result as (n_children, n_parents) before flattening.
+    if n_children >= n_parents:
         a = rng.standard_normal((n_children, n_parents))
         u, _, _ = np.linalg.svd(a, full_matrices=False)
-        q = u.T  # (n_parents, n_children)
+        q = u  # (n_children, n_parents), orthonormal columns
+    else:
+        a = rng.standard_normal((n_parents, n_children))
+        u, _, _ = np.linalg.svd(a, full_matrices=False)
+        q = u.T  # (n_children, n_parents), orthonormal rows
     return (gain * q).ravel()
 
 
@@ -160,3 +172,43 @@ def sparse_init(
     indices = rng.choice(size, size=n_nonzero, replace=False)
     weights[indices] = rng.normal(0.0, std, size=n_nonzero)
     return weights
+
+
+def _init_matrix(
+    init_fn: Callable,
+    n_children: int,
+    n_parents: int,
+    add_constant_input: bool,
+    seed: int,
+    kwargs: dict,
+) -> jnp.ndarray:
+    r"""Draw one ``weights_in`` matrix, keeping the bias column out of the statistics.
+
+    The bias column is not a connection to a parent, so it takes no part in either
+    half of an initialisation scheme. It is **excluded from the fan-in** and **initialised
+    to zero**.
+
+    Parameters
+    ----------
+    init_fn :
+        One of the strategies in :mod:`pyhgf.utils.weight_initialisation`.
+    n_children, n_parents :
+        Shape of the matrix, ``n_parents`` including the bias column when present.
+    add_constant_input :
+        Whether the last column is the bias.
+    seed :
+        Seed forwarded to *init_fn*.
+    kwargs :
+        Extra keyword arguments forwarded to *init_fn*.
+
+    Returns
+    -------
+    jnp.ndarray
+        The initialised matrix, shape ``(n_children, n_parents)``.
+    """
+    n_real = n_parents - 1 if add_constant_input else n_parents
+    flat = init_fn(n_real, n_children, seed=seed, **kwargs)
+    weights = np.asarray(flat).reshape(n_children, n_real)
+    if add_constant_input:
+        weights = np.concatenate([weights, np.zeros((n_children, 1))], axis=1)
+    return jnp.asarray(weights)

--- a/src/model/network.rs
+++ b/src/model/network.rs
@@ -1248,7 +1248,8 @@ impl Network {
                 if let Ok(weights) = weight_init_by_name(strategy, n_parents, n_children, seed) {
                     for (p_local, &parent_idx) in parent_nodes.iter().enumerate() {
                         for (c_local, &child_idx) in pre_layer.iter().enumerate() {
-                            let w = weights[p_local * n_children + c_local];
+                            // Row-major over (n_children, n_parents).
+                            let w = weights[c_local * n_parents + p_local];
                             crate::utils::set_coupling::set_coupling(
                                 self, parent_idx, child_idx, w,
                             );
@@ -1277,7 +1278,8 @@ impl Network {
 
             for (p_local, &parent_idx) in parent_nodes.iter().enumerate() {
                 for (c_local, &child_idx) in current_nodes.iter().enumerate() {
-                    let w = weights[p_local * n_current + c_local];
+                    // Row-major over (n_children, n_parents).
+                    let w = weights[c_local * n_parents + p_local];
                     crate::utils::set_coupling::set_coupling(self, parent_idx, child_idx, w);
                 }
             }

--- a/src/updates/vectorised/volatile/prediction.rs
+++ b/src/updates/vectorised/volatile/prediction.rs
@@ -61,15 +61,22 @@ pub fn layer_prediction(
 
     // 2. Value level.
     // Coupled parent activations (bias node = 1) and the per-parent Laplace
-    // variance factor (t·g'(μ̂))² / π̃_parent, built together in one pass. The
-    // bias parent has zero derivative and infinite precision → factor 0.
+    // variance factor g'(μ̂)² / π̃_parent, built together in one pass. The bias
+    // parent has zero derivative and infinite precision.
+    //
+    // No time step, unlike the nodalised backend: this term propagates the parent's
+    // uncertainty through the same map that produces `expected_mean` below, and that
+    // map is `W @ g(μ)` with no drift scaling. The nodalised path accumulates the
+    // value-parent contribution over the interval (`μ̂ = autoconnection·μ + t·drift`)
+    // and so carries `(t·ψ·g')²` to match. Mixing the two suppresses parent
+    // uncertainty by t² relative to the map it belongs to.
     let mut coupled = Array1::<Float>::zeros(p);
     let mut ppv = Array1::<Float>::zeros(p);
     with_coupling!(coupling_fn, |f, df, _d2f| {
         for j in 0..n_parent {
             let mu = parent.expected_mean[j];
             coupled[j] = f(mu as f64) as Float;
-            let num = time_step * df(mu as f64) as Float;
+            let num = df(mu as f64) as Float;
             ppv[j] = (num * num) / parent.expected_precision[j];
         }
     });

--- a/src/utils/weight_initialisation.rs
+++ b/src/utils/weight_initialisation.rs
@@ -1,7 +1,8 @@
 //! Weight initialisation strategies for predictive-coding neural networks.
 //!
 //! Each function takes a fan-in (`n_parents`) and fan-out (`n_children`) and returns a
-//! flat `Vec<f64>` of length `n_parents * n_children` (row-major) that can be used as
+//! flat `Vec<f64>` of length `n_parents * n_children`, row-major over an
+//! `(n_children, n_parents)` matrix, that can be used as
 //! initial coupling weights.
 //!
 //! Available strategies:
@@ -70,12 +71,14 @@ pub fn orthogonal_init(
     seed: Option<u64>,
 ) -> Vec<f64> {
     let mut rng = make_rng(seed);
-    let rows = n_parents;
-    let cols = n_children;
+    // The returned vector is row-major over (n_children, n_parents).
+    let rows = n_children;
+    let cols = n_parents;
     let dist = Normal::new(0.0, 1.0).unwrap();
 
     if rows >= cols {
-        // Tall or square: fill (rows, cols) matrix, orthogonalise columns.
+        // At least as many children as parents: orthonormal columns, so
+        // W^T W = I and every input direction keeps its length.
         let mut a: Vec<Vec<f64>> = (0..rows)
             .map(|_| (0..cols).map(|_| rng.sample(&dist)).collect())
             .collect();
@@ -88,12 +91,11 @@ pub fn orthogonal_init(
         }
         out
     } else {
-        // Wide: build (cols, rows) tall matrix, orthogonalise, then transpose.
+        // Fewer children than parents.
         let mut a: Vec<Vec<f64>> = (0..cols)
             .map(|_| (0..rows).map(|_| rng.sample(&dist)).collect())
             .collect();
         gram_schmidt_columns(&mut a, cols, rows);
-        // Transpose (cols, rows) → (rows, cols)
         let mut out = Vec::with_capacity(rows * cols);
         for r in 0..rows {
             for c in 0..cols {
@@ -229,20 +231,38 @@ mod tests {
     }
 
     #[test]
-    fn test_orthogonal_columns_are_unit() {
-        let n = 6;
-        let m = 4;
-        let w = orthogonal_init(n, m, 1.0, Some(42));
-        // Check each column has unit norm
-        for c in 0..m {
-            let mut norm_sq = 0.0;
-            for r in 0..n {
-                norm_sq += w[r * m + c] * w[r * m + c];
+    fn test_orthogonal_is_orthogonal_as_the_caller_reads_it() {
+        // The vector is row-major over (n_children, n_parents)
+        for &(n_parents, n_children) in &[(4usize, 6usize), (6usize, 4usize)] {
+            let w = orthogonal_init(n_parents, n_children, 1.0, Some(42));
+            assert_eq!(w.len(), n_parents * n_children);
+            let at = |r: usize, c: usize| w[r * n_parents + c];
+
+            if n_children >= n_parents {
+                // Orthonormal columns: W^T W = I over the parent index.
+                for a in 0..n_parents {
+                    for b in 0..n_parents {
+                        let dot: f64 = (0..n_children).map(|r| at(r, a) * at(r, b)).sum();
+                        let want = if a == b { 1.0 } else { 0.0 };
+                        assert!(
+                            (dot - want).abs() < 1e-10,
+                            "W^T W [{a},{b}] = {dot}, want {want}"
+                        );
+                    }
+                }
+            } else {
+                // Orthonormal rows: W W^T = I over the child index.
+                for a in 0..n_children {
+                    for b in 0..n_children {
+                        let dot: f64 = (0..n_parents).map(|c| at(a, c) * at(b, c)).sum();
+                        let want = if a == b { 1.0 } else { 0.0 };
+                        assert!(
+                            (dot - want).abs() < 1e-10,
+                            "W W^T [{a},{b}] = {dot}, want {want}"
+                        );
+                    }
+                }
             }
-            assert!(
-                (norm_sq - 1.0).abs() < 1e-10,
-                "column {c} norm² = {norm_sq}"
-            );
         }
     }
 

--- a/src/vectorised/batched.rs
+++ b/src/vectorised/batched.rs
@@ -222,7 +222,9 @@ fn batched_volatile_prediction(
     }
 
     // 2. Value level: coupled activations and the per-parent Laplace variance
-    // factor (t·g'(μ̂))² / π̃_parent (the bias row stays 0 there).
+    // factor g'(μ̂)² / π̃_parent (the bias row stays 0 there). No time step: it
+    // propagates parent uncertainty through the `W @ g(μ)` mean computed just below,
+    // which carries no drift scaling. See the single-sample path for the full note.
     let coupled = coupled_activations(
         &parent.expected_mean,
         parent_layer.coupling_fn,
@@ -234,7 +236,7 @@ fn batched_volatile_prediction(
             .and(&parent.expected_mean)
             .and(&parent.expected_precision)
             .for_each(|o, &mu, &ep| {
-                let num = time_step * df(mu as f64) as Float;
+                let num = df(mu as f64) as Float;
                 *o = (num * num) / ep;
             });
     });

--- a/src/vectorised/layer.rs
+++ b/src/vectorised/layer.rs
@@ -435,29 +435,32 @@ impl DeepNet {
     /// generators as the per-node backend
     /// ([`crate::utils::weight_initialisation`]).
     ///
-    /// Matches the JAX `DeepNetwork.weight_initialisation` semantics: the full
-    /// matrix is re-drawn **including the bias column**, and the same seed is
-    /// used for every layer (identically-shaped layers start identical).
     pub fn weight_initialisation(
         &mut self,
         strategy: &str,
         seed: Option<u64>,
     ) -> Result<(), String> {
         for layer in self.layers.iter_mut() {
+            let add_constant_input = layer.add_constant_input;
             let Some(w) = layer.weights_in.as_mut() else {
                 continue;
             };
             let (n_children, cols) = w.dim();
-            // Flat, row-major (n_children × cols), same layout as the JAX
-            // helpers' `.reshape(n_children, n_parents)`.
-            // The shared initialisers draw in f64 (they serve the nodalised
-            // backend too); narrow to the engine's Float here.
-            let flat: Vec<Float> = weight_init_by_name(strategy, cols, n_children, seed)?
+            let n_parents = if add_constant_input { cols - 1 } else { cols };
+            // Flat, row-major over (n_children, n_parents), the layout the
+            // shared initialisers document. They draw in f64 (they serve the
+            // nodalised backend too); narrow to the engine's Float here.
+            let flat: Vec<Float> = weight_init_by_name(strategy, n_parents, n_children, seed)?
                 .into_iter()
                 .map(|v| v as Float)
                 .collect();
-            *w = Matrix::from_shape_vec((n_children, cols), flat)
-                .expect("init vector length matches the weight shape");
+            let mut drawn = Matrix::zeros((n_children, cols));
+            for r in 0..n_children {
+                for c in 0..n_parents {
+                    drawn[[r, c]] = flat[r * n_parents + c];
+                }
+            }
+            *w = drawn;
         }
         Ok(())
     }
@@ -599,6 +602,40 @@ mod tests {
         let mut cfg = LayerConfig::new(2);
         cfg.state_overrides = vec![("not_a_field".to_string(), 1.0)];
         assert!(DeepNet::from_configs(&[cfg]).is_err());
+    }
+
+    #[test]
+    fn test_weight_initialisation_leaves_the_bias_column_out() {
+        // The bias is not a connection to a parent: it is zeroed, and it is
+        // excluded from the fan-in, so the drawn weights carry the scale of the
+        // real parent count rather than one more than it.
+        let configs = vec![LayerConfig::new(2), LayerConfig::new(3)];
+        let mut net = DeepNet::from_configs(&configs).unwrap();
+        assert!(net.layers[1].add_constant_input, "the layer carries a bias");
+
+        net.weight_initialisation("orthogonal", Some(0)).unwrap();
+        let w = net.layers[1].weights_in.as_ref().unwrap();
+        let (n_children, cols) = w.dim();
+        let n_parents = cols - 1;
+
+        for r in 0..n_children {
+            assert_eq!(w[[r, n_parents]], 0.0, "bias column must be zero");
+        }
+        // Orthogonality holds over the real parents only, which it cannot if
+        // the bias column took part in the draw. Which side is orthonormal
+        // depends on the shape: columns when there are at least as many
+        // children as parents, rows otherwise (the layer is then a projection).
+        if n_children >= n_parents {
+            for a in 0..n_parents {
+                let norm: Float = (0..n_children).map(|r| w[[r, a]] * w[[r, a]]).sum();
+                assert!((norm - 1.0).abs() < 1e-5, "column {a} norm² = {norm}");
+            }
+        } else {
+            for a in 0..n_children {
+                let norm: Float = (0..n_parents).map(|c| w[[a, c]] * w[[a, c]]).sum();
+                assert!((norm - 1.0).abs() < 1e-5, "row {a} norm² = {norm}");
+            }
+        }
     }
 
     #[test]

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -261,6 +261,47 @@ def test_weight_initialisation_strategies():
         # No error raised = success for Rust backend
 
 
+def test_orthogonal_initialisation_survives_the_reshape():
+    """Non-square matrices come out orthogonal once the caller has reshaped them.
+
+    ``orthogonal_init`` returns a flat vector that the caller reshapes row-major
+    to ``(n_children, n_parents)``. Both orientations are checked here on a network
+    whose layers are deliberately unequal: one matrix has more children than parents,
+    the other fewer.
+
+    With at least as many children as parents every input direction survives, so
+    ``W.T @ W = I``; with fewer, the layer is a projection and the best available is
+    ``W @ W.T = I``, preserving length within the row space.
+    """
+    net = (
+        DeepNetwork()
+        .add_layer(size=6)
+        .add_layer(size=3)
+        .add_layer(size=8)
+        .weight_initialisation("orthogonal", key=jax.random.key(0))
+    )
+
+    shapes = []
+    for layer in net.state.layers[1:]:
+        weights = np.asarray(layer.weights_in)
+        if layer.add_constant_input:
+            # The bias column is not a connection and takes no part in the
+            # orthogonality; it is zeroed by ``_init_matrix``.
+            np.testing.assert_allclose(weights[:, -1], 0.0, atol=0.0)
+            weights = weights[:, :-1]
+        n_children, n_parents = weights.shape
+        shapes.append((n_children, n_parents))
+        assert n_children != n_parents, "the square case cannot detect the scramble"
+        if n_children >= n_parents:
+            product, size = weights.T @ weights, n_parents
+        else:
+            product, size = weights @ weights.T, n_children
+        np.testing.assert_allclose(product, np.eye(size), atol=1e-6)
+
+    # One matrix of each orientation, so both branches were exercised.
+    assert any(c > p for c, p in shapes) and any(c < p for c, p in shapes), shapes
+
+
 def test_weight_initialisation_deterministic():
     """Same seed produces identical weights."""
     nets = []


### PR DESCRIPTION
Fixes the following numerical errors:

- The value-coupling variance carried the time step where its own mean did not: the predicted variance scaled as (t·g')², the mean as t·g. Both the JAX and the Rust paths are corrected to g'².

- The bias column took part in the initialisation statistics. It was drawn from the weight distribution, injecting a constant offset that accumulates down a deep stack. `_init_matrix` zeroes the bias and excludes it from the fan-in.

- `orthogonal_init` built its factor in (n_parents, n_children) order while callers reshape row-major to (n_children, n_parents). The returned matrix was not orthogonal at all except in the square case, where the reshape is a no-op.