### PR TITLE
Control precision prediction and updating for Deepnetwork

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -321,6 +321,7 @@ Volatile layers
    :toctree: generated/pyhgf.updates.vectorized.volatile
 
     vectorized_layer_prediction
+    vectorized_root_prediction
     vectorized_layer_posterior_update
     vectorized_posterior_update_precision_value_level
     vectorized_posterior_update_mean_value_level

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -603,7 +603,7 @@ Scan-based belief propagation used internally by :class:`pyhgf.model.DeepNetwork
    input_prediction_error
    sample_step
    batch_step
-   apply_confidence_increments
+   apply_precision_increments
    batched_prediction_pass
    batched_prediction_states
 

--- a/docs/source/notebooks/Example_5_Iowa_Gambling_Task.ipynb
+++ b/docs/source/notebooks/Example_5_Iowa_Gambling_Task.ipynb
@@ -605,7 +605,7 @@
     "\n",
     "2. **Extracting Beliefs**:\n",
     "   - `means`: Expected values for each deck.\n",
-    "   - `precisions`: Confidence in these beliefs, derived from the model's precision.\n",
+    "   - `precisions`: The precision of these beliefs, i.e. their inverse variance.\n",
     "\n",
     "3. **Decision Probabilities**:\n",
     "   - A softmax function combines `means` and `precisions` to compute the probability of selecting each deck.\n",

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -90,6 +90,8 @@ class DeepNetwork:
         (default), ``"eHGF"`` or ``"standard"``.
     max_posterior_precision :
         Upper bound applied to every posterior precision write. Defaults to ``1e10``.
+    update_input_layer :
+        Whether the belief sweeps reach the top (input) layer. Defaults to ``False``.
 
     Examples
     --------
@@ -125,6 +127,8 @@ class DeepNetwork:
         volatility_updates: str = "unbounded",
         max_posterior_precision: float = 1e10,
         precision_clipping_value: float = 1e-6,
+        update_input_layer: bool = False,
+        predict_precision: bool = True,
     ):
         r"""Initialize a VectorizedDeepNetwork.
 
@@ -151,11 +155,16 @@ class DeepNetwork:
             regimes; a very small value (default ``1e-6``) avoids flat, zero-gradient
             plateaus that hurt gradient-based inference. Shared with the nodalised
             ``Network`` and the Rust backend.
+        update_input_layer :
+            Whether the belief sweeps reach the top (input) layer, which holds the
+            predictors. Defaults to ``False``.
         """
         self.coupling_fn = coupling_fn
         self.volatility_updates = volatility_updates
         self.max_posterior_precision = float(max_posterior_precision)
         self.precision_clipping_value = float(precision_clipping_value)
+        self.update_input_layer = bool(update_input_layer)
+        self.predict_precision = bool(predict_precision)
         self.layer_sizes: list[int] = []
         self.layer_kinds: list[str] = []
         # Per-layer overrides for fields of ``LayerState`` and ``LayerParams``.
@@ -188,6 +197,7 @@ class DeepNetwork:
         volatility_updates: str = "unbounded",
         max_posterior_precision: float = 1e10,
         precision_clipping_value: float = 1e-6,
+        update_input_layer: bool = False,
     ) -> "DeepNetwork":
         """Build a network from a list of layer configurations.
 
@@ -209,6 +219,8 @@ class DeepNetwork:
             Upper bound applied to posterior precision writes.
         precision_clipping_value : float, default 1e-6
             Bound applied to binary-layer predicted means.
+        update_input_layer : bool, default False
+            Whether the belief sweeps reach the top (input) layer.
 
         Returns
         -------
@@ -245,6 +257,7 @@ class DeepNetwork:
             volatility_updates=volatility_updates,
             max_posterior_precision=max_posterior_precision,
             precision_clipping_value=precision_clipping_value,
+            update_input_layer=update_input_layer,
         )
 
         # Add layers in order
@@ -291,6 +304,7 @@ class DeepNetwork:
             - "volatility_updates" (optional): volatility update scheme
             - "max_posterior_precision" (optional): precision upper bound
             - "precision_clipping_value" (optional): binary-layer clipping bound
+            - "update_input_layer" (optional): whether the sweeps reach the top layer
 
         Returns
         -------
@@ -349,6 +363,7 @@ class DeepNetwork:
                 "volatility_updates",
                 "max_posterior_precision",
                 "precision_clipping_value",
+                "update_input_layer",
             )
         }
 
@@ -368,6 +383,11 @@ class DeepNetwork:
 
         Parameters
         ----------
+        predict_precision :
+            Whether the prediction sweep advances the precisions. With ``False``
+            each layer's predicted precisions are held at its prior precision, its
+            effective precision is zero and its volatility level is left untouched,
+            so prediction produces only the expected means.
         size :
             Number of nodes in the layer.
         kind :
@@ -632,6 +652,8 @@ class DeepNetwork:
             volatility_updates=self.volatility_updates,
             max_posterior_precision=self.max_posterior_precision,
             precision_clipping_value=self.precision_clipping_value,
+            update_input_layer=self.update_input_layer,
+            predict_precision=self.predict_precision,
         )
 
     def weight_initialisation(
@@ -742,6 +764,7 @@ class DeepNetwork:
         record: Optional[tuple] = None,
         weight_update: bool = True,
         time_step: float = 1.0,
+        update_confidences: bool = True,
     ) -> "DeepNetwork":
         r"""Fit network to data.
 
@@ -759,9 +782,8 @@ class DeepNetwork:
         learning_kind :
             Gradient computation mode passed to
             :func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient`:
-            ``"standard"`` or ``"precision_weighted"`` (default). Both are
-            strictly local. Each weight update reads only its own
-            connection's prediction error, activation, and precision.
+            ``"standard"`` or ``"precision_weighted"`` (default), both reading
+            the settled beliefs, strictly local per edge.
         record :
             Tuple of ``LayerState`` field names to record at every time step,
             e.g. ``("expected_mean", "precision")``. ``None`` (default) skips
@@ -773,10 +795,6 @@ class DeepNetwork:
             If True (default), the learning phase updates weights each step. If False,
             weights and ``opt_state`` are frozen. Useful for evaluating a fixed model on
             new data while still recording trajectories.
-        time_step :
-            Uniform inference time step :math:`\\Delta t` applied at every
-            ``propagation_step``. Replaces the legacy ``net.state.time_step``
-            attribute (``NetworkState`` no longer carries it). Default ``1.0``.
 
         Returns
         -------
@@ -813,6 +831,7 @@ class DeepNetwork:
             weight_update,
             record_tuple,
             float(time_step),
+            update_confidences,
         )
 
         if record_tuple:
@@ -947,12 +966,11 @@ class DeepNetwork:
     def input_error(self) -> jnp.ndarray:
         """Prediction error at the input (top) layer.
 
-        The bottom-up sweep leaves the top layer untouched (its values are
-        clamped to the predictors), so this is the only way to read the error
-        message the input would receive from the layer below — the child
+        The error message the input receives from the layer below — the child
         layer's prediction error, weighted by its confidence (precision) and
-        routed back through the connecting weights. Typical usage runs the
-        two sweeps first::
+        routed back through the connecting weights. It is read off the child,
+        so it does not depend on whether ``update_input_layer`` is set.
+        Typical usage runs the two sweeps first::
 
             net.prediction(x).update(y)
             error_at_input = net.input_error()
@@ -1023,7 +1041,7 @@ class DeepNetwork:
         e.g. many token positions learned together.
 
         The per-sample errors at the input layer are stored on
-        ``self.input_errors``, shape ``(batch, n_input_features)`` — see
+        ``self.input_errors``, shape ``(batch, n_input_features)``. See
         :meth:`input_error` for their meaning and sign convention.
 
         Parameters

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -764,7 +764,7 @@ class DeepNetwork:
         record: Optional[tuple] = None,
         weight_update: bool = True,
         time_step: float = 1.0,
-        update_confidences: bool = True,
+        update_precisions: bool = True,
     ) -> "DeepNetwork":
         r"""Fit network to data.
 
@@ -831,7 +831,7 @@ class DeepNetwork:
             weight_update,
             record_tuple,
             float(time_step),
-            update_confidences,
+            update_precisions,
         )
 
         if record_tuple:
@@ -967,7 +967,7 @@ class DeepNetwork:
         """Prediction error at the input (top) layer.
 
         The error message the input receives from the layer below — the child
-        layer's prediction error, weighted by its confidence (precision) and
+        layer's prediction error, weighted by its precision and
         routed back through the connecting weights. It is read off the child,
         so it does not depend on whether ``update_input_layer`` is set.
         Typical usage runs the two sweeps first::
@@ -1024,7 +1024,7 @@ class DeepNetwork:
         y: Union[np.ndarray, jnp.ndarray],
         optimizer: Optional[optax.GradientTransformation] = None,
         learning_kind: str = "precision_weighted",
-        update_confidences: bool = True,
+        update_precisions: bool = True,
         time_step: float = 1.0,
         predicted: Optional[tuple] = None,
         sample_weight: Optional[Union[np.ndarray, jnp.ndarray]] = None,
@@ -1032,11 +1032,11 @@ class DeepNetwork:
         """One batch-synchronous learning step over many samples at once.
 
         Every sample in the batch is processed from the same state — same
-        weights, same confidences — in parallel; the per-sample weight
-        gradients and confidence changes are then *averaged* and applied
+        weights, same precisions — in parallel; the per-sample weight
+        gradients and precision changes are then *averaged* and applied
         once, so the whole batch counts as a single observation. This
         differs from :meth:`fit`, which scans samples sequentially and lets
-        the confidences adapt from one sample to the next (the natural mode
+        the precisions adapt from one sample to the next (the natural mode
         for a time series). Use this method when samples are exchangeable —
         e.g. many token positions learned together.
 
@@ -1055,10 +1055,10 @@ class DeepNetwork:
             the weights.
         learning_kind :
             Weight-gradient mode, as in :meth:`fit`.
-        update_confidences :
+        update_precisions :
             If True (default), carry the batch-averaged change of the
-            confidence state (value-level precisions and the volatility
-            level) into ``self.state``. Set to False to keep confidences
+            precision state (value-level precisions and the volatility
+            level) into ``self.state``. Set to False to keep the precisions
             pinned, e.g. for exact comparisons against backpropagation.
         time_step :
             Inference time step, applied once per batch.
@@ -1101,7 +1101,7 @@ class DeepNetwork:
             y,
             optimizer=optimizer,
             learning_kind=learning_kind,
-            update_confidences=update_confidences,
+            update_precisions=update_precisions,
             time_step=float(time_step),
             predicted=predicted,
             sample_weight=None if sample_weight is None else jnp.asarray(sample_weight),

--- a/pyhgf/model/fused.py
+++ b/pyhgf/model/fused.py
@@ -74,7 +74,7 @@ def _adapter_core(part: DeepNetworkAdapter, path: str) -> _Core:
     """
     optimizer = part.optimizer
     learning_kind = part.learning_kind
-    update_confidences = part.update_confidences
+    update_precisions = part.update_precisions
     time_step = part.time_step
     layer_sizes = list(part.net.layer_sizes)
 
@@ -107,7 +107,7 @@ def _adapter_core(part: DeepNetworkAdapter, path: str) -> _Core:
             out - error.reshape(-1, error.shape[-1]),
             optimizer=optimizer,
             learning_kind=learning_kind,
-            update_confidences=update_confidences,
+            update_precisions=update_precisions,
             time_step=time_step,
             predicted=states,
         )

--- a/pyhgf/model/hybrid.py
+++ b/pyhgf/model/hybrid.py
@@ -295,12 +295,12 @@ class DeepNetworkAdapter(PCModule):
         weights (the beliefs still update).
     learning_kind :
         Weight-gradient mode, as in :meth:`~pyhgf.model.DeepNetwork.fit`.
-    update_confidences :
-        Whether the confidence state adapts across batches (see
+    update_precisions :
+        Whether the precision state adapts across batches (see
         :meth:`~pyhgf.model.DeepNetwork.batch_update`). Defaults to False —
         the setting used for exact comparisons against backpropagation.
     time_step :
-        Inference time step — scales the confidence leak per batch (one batch
+        Inference time step — scales the precision leak per batch (one batch
         counts as one observation of duration ``time_step``).
     """
 
@@ -309,13 +309,13 @@ class DeepNetworkAdapter(PCModule):
         net: DeepNetwork,
         optimizer: Optional[optax.GradientTransformation] = None,
         learning_kind: str = "precision_weighted",
-        update_confidences: bool = False,
+        update_precisions: bool = False,
         time_step: float = 1.0,
     ):
         self.net = net
         self.optimizer = optimizer
         self.learning_kind = learning_kind
-        self.update_confidences = update_confidences
+        self.update_precisions = update_precisions
         self.time_step = time_step
 
     def init_state(self) -> tuple:

--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -325,12 +325,20 @@ class Network(eqx.Module):
         The volatility update scheme, e.g. ``"unbounded"``.
     max_posterior_precision :
         The maximum posterior precision used to clip the precision updates.
+    update_input_layer :
+        Whether the sweeps reach the top (input) layer — see
+        :class:`pyhgf.model.DeepNetwork`.
+    predict_precision :
+        Whether the prediction sweep advances the precisions — see
+        :func:`pyhgf.updates.vectorized.volatile.prediction.vectorized_layer_prediction`.
     """
 
     layers: tuple
     volatility_updates: str = field(static=True)
     max_posterior_precision: float = field(static=True)
     precision_clipping_value: float = field(static=True, default=1e-6)
+    update_input_layer: bool = field(static=True, default=False)
+    predict_precision: bool = field(static=True, default=True)
 
     @property
     def n_layers(self) -> int:

--- a/pyhgf/updates/vectorized/volatile/__init__.py
+++ b/pyhgf/updates/vectorized/volatile/__init__.py
@@ -12,7 +12,7 @@ from .posterior import (
     vectorized_posterior_update_mean_value_level,
     vectorized_posterior_update_precision_value_level,
 )
-from .prediction import vectorized_layer_prediction
+from .prediction import vectorized_layer_prediction, vectorized_root_prediction
 from .prediction_error import (
     vectorized_layer_prediction_error,
     vectorized_layer_value_prediction_error,
@@ -33,4 +33,5 @@ __all__ = [
     "vectorized_layer_volatility_posterior_unbounded",
     "vectorized_posterior_update_mean_value_level",
     "vectorized_posterior_update_precision_value_level",
+    "vectorized_root_prediction",
 ]

--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -295,7 +295,7 @@ def vectorized_root_prediction(
         \hat{\pi}_a^{(k)} = \tilde{\pi}_a^{(k)}
             = \left( \frac{1}{\pi_a^{(k-1)}} + \Omega_a^{(k)} \right)^{-1}.
 
-    This is what lets the input layer's confidence *move*. Without it,
+    This is what lets the input layer's precision *move*. Without it,
     ``expected_precision`` is frozen at whatever the layer was built with, and
     because the layer below reads it to form its own value-coupling variance, the
     whole hierarchy inherits a constant input precision. Running this kernel makes

--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -12,6 +12,67 @@ from jax import Array, grad, vmap
 from pyhgf.typing.vectorised import LayerParams, LayerState
 
 
+def _predict_volatility_level(
+    state: LayerState,
+    params: LayerParams,
+    time_step: float,
+    has_volatility_parent: bool,
+) -> tuple[Optional[Array], Optional[Array], Optional[Array], Array]:
+    r"""Advance a layer's internal volatility level and read off its diffusion term.
+
+    Shared by every value-level prediction, whether the layer is predicted from a
+    parent (:func:`vectorized_layer_prediction`) or from nothing at all
+    (:func:`vectorized_root_prediction`).
+
+    Returns ``(expected_mean_vol, expected_precision_vol, effective_precision_vol,
+    predicted_volatility)``. The last is :math:`\Omega_a^{(k)}`, the variance the
+    value level accumulates over this time step; it carries the closed-form
+    moment-generating-function correction :math:`1 / (2 \hat{\pi}_{\mathrm{vol}})`
+    that comes from marginalising over the volatility level's Gaussian rather than
+    collapsing it to a point estimate. Volatility coupling is fixed at 1 and the
+    value level carries no tonic volatility of its own.
+
+    Without a volatility parent the level is frozen: its three fields pass through
+    unchanged and the diffusion term is zero, so the value level does not undergo a
+    Gaussian random walk between observations.
+    """
+    if not has_volatility_parent:
+        return (
+            state.mean_vol,
+            state.precision_vol,
+            state.effective_precision_vol,
+            jnp.zeros_like(state.precision),
+        )
+
+    assert state.mean_vol is not None
+    assert state.precision_vol is not None
+
+    # Autoconnection strength of the volatility level is fixed at 1.
+    expected_mean_vol = state.mean_vol
+
+    predicted_volatility_vol = time_step * jnp.exp(params.tonic_volatility_vol)
+    predicted_volatility_vol = jnp.where(
+        predicted_volatility_vol > 1e-128, predicted_volatility_vol, jnp.nan
+    )
+    expected_precision_vol = 1.0 / (
+        1.0 / state.precision_vol + predicted_volatility_vol
+    )
+    effective_precision_vol = predicted_volatility_vol * expected_precision_vol
+
+    total_volatility = expected_mean_vol + 1.0 / (2.0 * expected_precision_vol)
+    predicted_volatility = time_step * jnp.exp(total_volatility)
+    predicted_volatility = jnp.where(
+        predicted_volatility > 1e-128, predicted_volatility, jnp.nan
+    )
+
+    return (
+        expected_mean_vol,
+        expected_precision_vol,
+        effective_precision_vol,
+        predicted_volatility,
+    )
+
+
 def vectorized_layer_prediction(
     child_state: LayerState,
     parent_state: LayerState,
@@ -22,6 +83,7 @@ def vectorized_layer_prediction(
     parent_has_constant: bool = False,
     has_volatility_parent: bool = True,
     is_input_layer: bool = False,
+    predict_precision: bool = True,
 ) -> LayerState:
     r"""Predict expected mean/precision for all nodes in a volatile-node layer.
 
@@ -70,12 +132,23 @@ def vectorized_layer_prediction(
         regardless of *coupling_fn*; the constant node's derivative is zero and
         its predicted precision is infinite, so it contributes nothing to the
         value-coupling variance.
+    predict_precision :
+        Whether the prediction step advances the precisions; see
+        :func:`vectorized_layer_prediction`.
     has_volatility_parent :
         If True (default), the layer has an implied internal volatility parent
         whose state (``mean_vol``, ``precision_vol``) is predicted and updated.
         If False, the value level has no volatility source at all, so it does not
         undergo a Gaussian random walk: the diffusion term is dropped and the
         conditional predicted precision equals the prior precision.
+    predict_precision :
+        Whether the prediction step advances the precisions at all. With ``False``
+        both predicted precisions are held at the layer's prior precision, the
+        effective precision is zero, and the volatility level is left untouched,
+        so the only thing prediction produces is the expected mean. Precision then
+        moves solely through the posterior update, if that is enabled. This is the
+        same treatment ``is_input_layer`` gives an observed leaf, applied to every
+        layer.
     is_input_layer :
         If True, the layer is treated as an observed input/leaf: it does not
         undergo a Gaussian random walk between observations. The volatility
@@ -93,30 +166,20 @@ def vectorized_layer_prediction(
     """
     # 1. VOLATILITY LEVEL PREDICTION (internal) ----------------------------------------
     # ----------------------------------------------------------------------------------
-    expected_mean_vol: Optional[Array]
-    expected_precision_vol: Optional[Array]
-    effective_precision_vol: Optional[Array]
-    if has_volatility_parent:
-        assert child_state.mean_vol is not None
-        assert child_state.precision_vol is not None
-        # Expected mean for volatility level (autoconnection strength fixed at 1).
-        expected_mean_vol = child_state.mean_vol
-
-        # Predicted volatility for volatility level
-        predicted_volatility_vol = time_step * jnp.exp(params.tonic_volatility_vol)
-        predicted_volatility_vol = jnp.where(
-            predicted_volatility_vol > 1e-128, predicted_volatility_vol, jnp.nan
+    if predict_precision:
+        (
+            expected_mean_vol,
+            expected_precision_vol,
+            effective_precision_vol,
+            predicted_volatility,
+        ) = _predict_volatility_level(
+            child_state, params, time_step, has_volatility_parent
         )
-
-        # Expected precision for volatility level
-        expected_precision_vol = 1.0 / (
-            1.0 / child_state.precision_vol + predicted_volatility_vol
-        )
-
-        # Effective precision for volatility level
-        effective_precision_vol = predicted_volatility_vol * expected_precision_vol
     else:
-        # Volatility level is frozen — pass through current values unchanged
+        # Nothing downstream reads the volatility level when the value-level
+        # precisions are frozen: its only route into the value level is the
+        # diffusion term, and its own posterior update is driven by the effective
+        # precision, which is zero below.
         expected_mean_vol = child_state.mean_vol
         expected_precision_vol = child_state.precision_vol
         effective_precision_vol = child_state.effective_precision_vol
@@ -142,63 +205,50 @@ def vectorized_layer_prediction(
     # Here we remove the influence of time_step on the expected mean.
     expected_mean = jnp.matmul(weights, coupled_parents)
 
-    if has_volatility_parent:
-        assert expected_mean_vol is not None
-        assert expected_precision_vol is not None
-        # Total volatility is the internal volatility level's expected mean plus
-        # the closed-form moment-generating-function correction 1 / (2 · π̂_vol)
-        # that arises from marginalising over the volatility level's Gaussian
-        # rather than collapsing it to a point estimate. The volatility coupling
-        # is fixed at 1, and the value level carries no tonic volatility of its own.
-        total_volatility = expected_mean_vol + 1.0 / (2.0 * expected_precision_vol)
-        # Predicted volatility for value level
-        predicted_volatility = time_step * jnp.exp(total_volatility)
-        predicted_volatility = jnp.where(
-            predicted_volatility > 1e-128, predicted_volatility, jnp.nan
+    if predict_precision:
+        # Laplace value-coupling correction. Linearising g at μ̂_b and marginalising
+        # over each parent's Gaussian yields, per child node i, the additional variance
+        #     Σ_j (t · W[i, j] · g'(μ̂_j))² / π̃_j,
+        # using the parent's marginal predicted precision π̃_j (= `expected_precision`).
+        # The constant-bias parent (if any) has infinite precision and contributes zero.
+        parent_precision = parent_state.expected_precision
+        g_prime = vmap(grad(coupling_fn))(parent_state.expected_mean)
+        if parent_has_constant:
+            # The constant node never varies: zero derivative, infinite precision.
+            parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
+            g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
+        # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ (g'² / π): the
+        # weight-dependent factor is a constant matrix, so the per-node sum is a
+        # matrix product with a per-node vector.
+        # The variance carries no time step (deviation from the Network class).
+        per_parent_variance = g_prime**2 / parent_precision
+        value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
+
+        # Conditional predicted precision π̂_a — the precision of x_a given a specific
+        # value of x_b (own AR-plus-volatility variance only, no parent-uncertainty
+        # bleed-through). This is the precision that enters the joint (x_a, x_b)
+        # Gaussian's Schur complement at the parent's posterior-step (smoothing)
+        # correction; substituting π̃_a there would double-count parent uncertainty.
+        conditional_expected_precision = 1.0 / (
+            1.0 / child_state.precision + predicted_volatility
         )
+
+        # Marginal predicted precision π̃_a — inverse marginal predictive variance,
+        # adding the law-of-total-variance bleed-through to the conditional variance.
+        expected_precision = 1.0 / (
+            1.0 / conditional_expected_precision + value_coupling_variance
+        )
+
+        # Effective precision γ — only the volatility-driven part enters γ, since γ
+        # is consumed by the volatility-coupling posterior update.
+        effective_precision = predicted_volatility * expected_precision
     else:
-        # No volatility parent and no tonic volatility: the value level has no
-        # volatility source, so it does not undergo a Gaussian random walk between
-        # observations. Dropping the diffusion term leaves the conditional
-        # predicted precision equal to the prior precision (see below).
-        predicted_volatility = jnp.zeros_like(child_state.precision)
-
-    # Laplace value-coupling correction. Linearising g at μ̂_b and marginalising
-    # over each parent's Gaussian yields, per child node i, the additional variance
-    #     Σ_j (t · W[i, j] · g'(μ̂_j))² / π̃_j,
-    # using the parent's marginal predicted precision π̃_j (= `expected_precision`).
-    # The constant-bias parent (if any) has infinite precision and contributes zero.
-    parent_precision = parent_state.expected_precision
-    g_prime = vmap(grad(coupling_fn))(parent_state.expected_mean)
-    if parent_has_constant:
-        # The constant node never varies: zero derivative, infinite precision.
-        parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
-        g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
-    # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ (g'² / π): the
-    # weight-dependent factor is a constant matrix, so the per-node sum is a
-    # matrix product with a per-node vector.
-    # The variance carries no time step (deviation from the Network class).
-    per_parent_variance = g_prime**2 / parent_precision
-    value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
-
-    # Conditional predicted precision π̂_a — the precision of x_a given a specific
-    # value of x_b (own AR-plus-volatility variance only, no parent-uncertainty
-    # bleed-through). This is the precision that enters the joint (x_a, x_b)
-    # Gaussian's Schur complement at the parent's posterior-step (smoothing)
-    # correction; substituting π̃_a there would double-count parent uncertainty.
-    conditional_expected_precision = 1.0 / (
-        1.0 / child_state.precision + predicted_volatility
-    )
-
-    # Marginal predicted precision π̃_a — inverse marginal predictive variance,
-    # adding the law-of-total-variance bleed-through to the conditional variance.
-    expected_precision = 1.0 / (
-        1.0 / conditional_expected_precision + value_coupling_variance
-    )
-
-    # Effective precision γ — only the volatility-driven part enters γ, since γ
-    # is consumed by the volatility-coupling posterior update.
-    effective_precision = predicted_volatility * expected_precision
+        # Frozen: both predicted precisions stay at the prior and nothing is
+        # carried into the volatility-coupling update. The parent's derivative is
+        # not needed either, so the autodiff call is skipped with it.
+        conditional_expected_precision = child_state.precision
+        expected_precision = child_state.precision
+        effective_precision = jnp.zeros_like(child_state.precision)
 
     # Input/leaf override: an observed layer with no value children does not
     # undergo a Gaussian random walk between observations, so the
@@ -216,6 +266,92 @@ def vectorized_layer_prediction(
         expected_mean=expected_mean,
         expected_precision=expected_precision,
         conditional_expected_precision=conditional_expected_precision,
+        effective_precision=effective_precision,
+        expected_mean_vol=expected_mean_vol,
+        expected_precision_vol=expected_precision_vol,
+        effective_precision_vol=effective_precision_vol,
+    )
+
+
+def vectorized_root_prediction(
+    layer_state: LayerState,
+    params: LayerParams,
+    time_step: float,
+    has_volatility_parent: bool = True,
+    predict_precision: bool = True,
+) -> LayerState:
+    r"""Predict the precisions of a layer that has no value parent above it.
+
+    The top (input) layer of a deep network is clamped to the predictors, so its
+    expected mean is supplied from outside the hierarchy rather than produced by a
+    parent's top-down prediction. Everything else about it is still predicted: the
+    volatility level advances exactly as it does anywhere else, and the value-level
+    predicted precisions follow the same chain as
+    :func:`vectorized_layer_prediction`, minus the value-coupling variance. The conditional and the
+    marginal predicted precision therefore coincide:
+
+    .. math::
+
+        \hat{\pi}_a^{(k)} = \tilde{\pi}_a^{(k)}
+            = \left( \frac{1}{\pi_a^{(k-1)}} + \Omega_a^{(k)} \right)^{-1}.
+
+    This is what lets the input layer's confidence *move*. Without it,
+    ``expected_precision`` is frozen at whatever the layer was built with, and
+    because the layer below reads it to form its own value-coupling variance, the
+    whole hierarchy inherits a constant input precision. Running this kernel makes
+    that quantity track the evidence the layer has accumulated: the posterior
+    precision written by the bottom-up sweep enters here on the next step, damped by
+    the volatility level.
+
+    ``expected_mean`` is deliberately left untouched.
+
+    Parameters
+    ----------
+    layer_state :
+        Current state of the layer, carrying the posterior ``precision`` (and, with a
+        volatility parent, ``precision_vol`` / ``mean_vol``) left by the previous step.
+    params :
+        Layer parameters for this layer.
+    time_step :
+        Time step :math:`t^{(k)}` for the prediction.
+    has_volatility_parent :
+        If True (default), the implied internal volatility parent is predicted and
+        contributes a diffusion term to the value level. If False, the value level has
+        no volatility source, so it does not drift between observations and the
+        predicted precision is just the prior precision.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with the predicted precisions of both levels populated,
+        and ``expected_mean`` unchanged.
+    """
+    if predict_precision:
+        (
+            expected_mean_vol,
+            expected_precision_vol,
+            effective_precision_vol,
+            predicted_volatility,
+        ) = _predict_volatility_level(
+            layer_state, params, time_step, has_volatility_parent
+        )
+
+        # No value parent, hence no value-coupling variance: the conditional and
+        # the marginal predicted precision are the same quantity.
+        expected_precision = 1.0 / (1.0 / layer_state.precision + predicted_volatility)
+        effective_precision = predicted_volatility * expected_precision
+    else:
+        # Frozen, as in :func:`vectorized_layer_prediction`.
+        expected_mean_vol = layer_state.mean_vol
+        expected_precision_vol = layer_state.precision_vol
+        effective_precision_vol = layer_state.effective_precision_vol
+        expected_precision = layer_state.precision
+        effective_precision = jnp.zeros_like(layer_state.precision)
+
+    return dataclasses.replace(
+        layer_state,
+        expected_precision=expected_precision,
+        conditional_expected_precision=expected_precision,
         effective_precision=effective_precision,
         expected_mean_vol=expected_mean_vol,
         expected_precision_vol=expected_precision_vol,

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -330,7 +330,7 @@ def _top_precision_only(
     (:func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient_factors`
     forms the parent-side factor from ``coupling_fn(parent.mean)``). Those weights must
     be learned against the predictors that were actually supplied, so the mean stays
-    pinned to ``x`` and only the confidence in it moves.
+    pinned to ``x`` and only its precision moves.
 
     Two things follow from the clamp, and both are deliberate:
 
@@ -558,7 +558,7 @@ def _sweeps_reach_top(network: Network) -> bool:
 
     Gating the two sweeps on one predicate keeps them in step: a top element that
     receives a posterior update must also receive the precision prediction that
-    carries it into the next step, or its confidence would accumulate with nothing
+    carries it into the next step, or its precision would accumulate with nothing
     advancing it.
 
     Requires ``update_input_layer``, something below the top to send it a message,
@@ -577,7 +577,7 @@ def _predict_top_precisions(elem, *, time_step: float):
     """Predict the top element's precisions, which no parent above it can supply.
 
     The element's ``expected_mean`` stays clamped to the predictors; what this adds is
-    the predicted precision of both levels, so the confidence the bottom-up sweep wrote
+    the predicted precision of both levels, so the precision the bottom-up sweep wrote
     into ``precision`` on the previous step is carried forward (damped by the volatility
     level) instead of being ignored.
     """
@@ -691,7 +691,7 @@ def run_scan(
     weight_update: bool,
     record: tuple,
     time_step: float = 1.0,
-    update_confidences: bool = True,
+    update_precisions: bool = True,
 ) -> tuple:
     r"""Run ``jax.lax.scan`` over the belief-propagation step.
 
@@ -744,11 +744,11 @@ def run_scan(
             learning_kind=learning_kind,
             weight_update=weight_update,
         )
-        if not update_confidences:
+        if not update_precisions:
             # Static-cascade mode: precisions are parameters, not filter state. Note
             # that recorded carried fields then show the template values, since the
             # restore runs before recording.
-            new_network = _restore_confidences(new_network, template)
+            new_network = _restore_precisions(new_network, template)
         if record:
             traj_step = {
                 field: tuple(getattr(elem.state, field) for elem in new_network.layers)
@@ -806,7 +806,7 @@ def _update_sweep(
     on different terms from the interior: its mean stays clamped to the predictors and
     only its precision moves (see :func:`_top_precision_only`). The top element holds
     observed inputs that the weight update reads back, so its value is not the
-    network's to revise, only its confidence in that value is.
+    network's to revise, only its precision is.
     """
     elements = list(network.layers)
     n_elements = len(elements)
@@ -1027,8 +1027,8 @@ def learn_sweep(
 _CARRIED_FIELDS: tuple = ("precision", "mean_vol", "precision_vol")
 
 
-def _confidence_increments(before: Network, after: Network) -> tuple:
-    """Per-element change of the carried confidence fields, ``after - before``.
+def _precision_increments(before: Network, after: Network) -> tuple:
+    """Per-element change of the carried precision fields, ``after - before``.
 
     Returns one ``dict`` per element, keyed by field name. For a ``Layer``
     each entry has shape ``(n_nodes,)``; for a ``LayerStack``,
@@ -1046,10 +1046,10 @@ def _confidence_increments(before: Network, after: Network) -> tuple:
     )
 
 
-def apply_confidence_increments(network: Network, increments: tuple) -> Network:
-    """Add confidence increments (see :func:`_confidence_increments`) to a network.
+def apply_precision_increments(network: Network, increments: tuple) -> Network:
+    """Add precision increments (see :func:`_precision_increments`) to a network.
 
-    Used by :func:`batch_step` to carry the batch-averaged confidence change into the
+    Used by :func:`batch_step` to carry the batch-averaged precision change into the
     state used by the next batch.
     """
     new_elements = []
@@ -1066,8 +1066,8 @@ def apply_confidence_increments(network: Network, increments: tuple) -> Network:
     return dataclasses.replace(network, layers=tuple(new_elements))
 
 
-def _restore_confidences(network: Network, template: Network) -> Network:
-    """Reset the carried confidence fields to a template's values.
+def _restore_precisions(network: Network, template: Network) -> Network:
+    """Reset the carried precision fields to a template's values.
 
     The inverse of carrying: with this applied after every propagation step, each
     sample's sweeps still compute full per-sample posteriors but the filtered
@@ -1104,7 +1104,7 @@ def sample_step(
     ----------
     network :
         The state template. Not modified; every call starting from the same
-        template sees the same weights and the same confidences, which is
+        template sees the same weights and the same precisions, which is
         what makes this function safe to ``jax.vmap`` over a batch of
         samples.
     x :
@@ -1127,10 +1127,10 @@ def sample_step(
         Per-element weight gradients (descent form, ``None`` for the bottom
         element). Average these across a batch and apply once.
     increments :
-        Per-element change of the carried confidence fields (value-level
+        Per-element change of the carried precision fields (value-level
         posterior precision and the volatility level), relative to the
         template. Average these across a batch and apply once with
-        :func:`apply_confidence_increments`.
+        :func:`apply_precision_increments`.
     """
     updated = _update_sweep(
         _prediction_sweep(network, x, time_step=time_step), y, time_step=time_step
@@ -1138,7 +1138,7 @@ def sample_step(
     return (
         _input_prediction_error(updated),
         _weight_gradients(updated, learning_kind),
-        _confidence_increments(network, updated),
+        _precision_increments(network, updated),
     )
 
 
@@ -1149,7 +1149,7 @@ def _batch_step(
     y: jnp.ndarray,
     optimizer: Optional[optax.GradientTransformation] = None,
     learning_kind: str = "precision_weighted",
-    update_confidences: bool = True,
+    update_precisions: bool = True,
     time_step: float = 1.0,
     predicted: Optional[tuple] = None,
     sample_weight: Optional[jnp.ndarray] = None,
@@ -1157,15 +1157,15 @@ def _batch_step(
     """One batch-synchronous learning step over many samples at once.
 
     Every sample in the batch is processed from the *same* state template —
-    same weights, same confidences — through the same sweeps as
+    same weights, same precisions — through the same sweeps as
     :func:`sample_step`, under ``jax.vmap``, so samples are exchangeable and
     nothing depends on their order. The per-sample results are then averaged
     and applied once, so the batch counts as a single observation:
 
     * the mean weight gradient drives one optimiser step (skipped when
       ``optimizer`` is ``None``);
-    * the mean confidence increments are added to the carried fields (skipped
-      when ``update_confidences`` is ``False``, e.g. to keep the carried
+    * the mean precision increments are added to the carried fields (skipped
+      when ``update_precisions`` is ``False``, e.g. to keep the carried
       precisions pinned when comparing against backpropagation).
 
     Averaging (rather than summing) makes the result invariant to repeating
@@ -1185,8 +1185,8 @@ def _batch_step(
         Optax optimiser for the weight step. ``None`` freezes the weights.
     learning_kind :
         Weight-gradient mode.
-    update_confidences :
-        Whether to carry the batch-averaged confidence increments into the
+    update_precisions :
+        Whether to carry the batch-averaged precision increments into the
         returned network.
     time_step :
         Inference time step, applied once per batch.
@@ -1215,7 +1215,7 @@ def _batch_step(
     -------
     network :
         The template advanced by one batch: new weights and, if requested,
-        new confidences. Everything else is untouched (it is rewritten by
+        new precisions. Everything else is untouched (it is rewritten by
         the sweeps on the next call anyway).
     opt_state :
         The advanced optimiser state (``None`` if no optimiser was given).
@@ -1239,7 +1239,7 @@ def _batch_step(
             )
         return (
             _input_prediction_error(updated),
-            _confidence_increments(network, updated),
+            _precision_increments(network, updated),
             factors,
         )
 
@@ -1273,7 +1273,7 @@ def _batch_step(
             new_network, mean_grads, opt_state, optimizer
         )
 
-    if update_confidences:
+    if update_precisions:
         if sample_weight is None:
             reduce = lambda i: i.mean(axis=0)  # noqa: E731
         else:
@@ -1283,7 +1283,7 @@ def _batch_step(
                 return jnp.tensordot(sample_weight, i, axes=(0, 0)) / denominator
 
         mean_increments = jax.tree_util.tree_map(reduce, increments)
-        new_network = apply_confidence_increments(new_network, mean_increments)
+        new_network = apply_precision_increments(new_network, mean_increments)
 
     return new_network, opt_state, input_errors
 

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -573,19 +573,23 @@ def _sweeps_reach_top(network: Network) -> bool:
     )
 
 
-def _predict_top_precisions(elem, *, time_step: float):
+def _predict_top_precisions(elem, *, time_step: float, predict_precision: bool = True):
     """Predict the top element's precisions, which no parent above it can supply.
 
     The element's ``expected_mean`` stays clamped to the predictors; what this adds is
     the predicted precision of both levels, so the precision the bottom-up sweep wrote
     into ``precision`` on the previous step is carried forward (damped by the volatility
     level) instead of being ignored.
+
+    ``predict_precision`` is threaded through: the network-level switch has to reach the
+    top element as well, or it would keep diffusing while every layer below it froze.
     """
     new_state = vectorized_root_prediction(
         layer_state=elem.state,
         params=elem.params,
         time_step=time_step,
         has_volatility_parent=elem.has_volatility_parent,
+        predict_precision=predict_precision,
     )
     return dataclasses.replace(elem, state=new_state)
 
@@ -777,7 +781,11 @@ def _prediction_sweep(
 
     elements[-1] = _set_top_predictors(elements[-1], x)
     if _sweeps_reach_top(network):
-        elements[-1] = _predict_top_precisions(elements[-1], time_step=time_step)
+        elements[-1] = _predict_top_precisions(
+            elements[-1],
+            time_step=time_step,
+            predict_precision=network.predict_precision,
+        )
 
     for i in range(n_elements - 1, 0, -1):
         elements[i - 1] = _topdown_predict(

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -37,6 +37,8 @@ from pyhgf.updates.vectorized.volatile import (
     vectorized_layer_posterior_update,
     vectorized_layer_prediction,
     vectorized_layer_prediction_error,
+    vectorized_posterior_update_precision_value_level,
+    vectorized_root_prediction,
 )
 
 # ---------------------------------------------------------------------------
@@ -99,6 +101,7 @@ def _predict_layer_from_parent(
     *,
     time_step: float,
     precision_clipping_value: float,
+    predict_precision: bool = True,
 ):
     """Predict a single ``Layer`` child from a parent view."""
     if child.kind == "binary":
@@ -129,6 +132,7 @@ def _predict_layer_from_parent(
             parent_has_constant=parent_has_constant,
             has_volatility_parent=child.has_volatility_parent,
             is_input_layer=child.is_input_layer,
+            predict_precision=predict_precision,
         )
     return dataclasses.replace(child, state=new_state)
 
@@ -141,6 +145,7 @@ def _predict_stack_from_parent(
     parent_has_constant: bool,
     *,
     time_step: float,
+    predict_precision: bool = True,
 ):
     """Top-down sweep over a ``LayerStack``.
 
@@ -163,6 +168,7 @@ def _predict_stack_from_parent(
         parent_has_constant=parent_has_constant,
         has_volatility_parent=stack.has_volatility_parent,
         is_input_layer=False,
+        predict_precision=predict_precision,
     )
 
     # xs: per-iteration data for predicting slices N-2 ... 0 from the slice above.
@@ -187,6 +193,7 @@ def _predict_stack_from_parent(
             parent_has_constant=stack.add_constant_input,
             has_volatility_parent=stack.has_volatility_parent,
             is_input_layer=False,
+            predict_precision=predict_precision,
         )
         return new_child_state, new_child_state
 
@@ -208,7 +215,12 @@ def _predict_stack_from_parent(
 
 
 def _topdown_predict(
-    parent_elem, child_elem, *, time_step: float, precision_clipping_value: float
+    parent_elem,
+    child_elem,
+    *,
+    time_step: float,
+    precision_clipping_value: float,
+    predict_precision: bool = True,
 ):
     """Predict ``child_elem`` from ``parent_elem``.
 
@@ -226,6 +238,7 @@ def _topdown_predict(
             parent_coupling_fn,
             parent_has_const,
             time_step=time_step,
+            predict_precision=predict_precision,
         )
     return _predict_layer_from_parent(
         child_elem,
@@ -235,6 +248,7 @@ def _topdown_predict(
         parent_has_const,
         time_step=time_step,
         precision_clipping_value=precision_clipping_value,
+        predict_precision=predict_precision,
     )
 
 
@@ -300,6 +314,62 @@ def _posterior_pe_layer(
             has_volatility_parent=parent.has_volatility_parent,
             max_posterior_precision=max_posterior_precision,
         )
+    return dataclasses.replace(parent, state=new_state)
+
+
+def _top_precision_only(
+    parent: Layer,
+    child_state,
+    child_is_input_layer: bool,
+    *,
+    max_posterior_precision: float,
+):
+    r"""Update the top layer's precision from the layer below, leaving its mean clamped.
+
+    The top layer holds the predictors, and its mean is read back by the weight update
+    (:func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient_factors`
+    forms the parent-side factor from ``coupling_fn(parent.mean)``). Those weights must
+    be learned against the predictors that were actually supplied, so the mean stays
+    pinned to ``x`` and only the confidence in it moves.
+
+    Two things follow from the clamp, and both are deliberate:
+
+    * The value prediction error is identically zero. A layer whose mean never leaves
+      its prediction has no residual, so the field is written as zero rather than left
+      holding a stale value.
+    * The volatility level is *not* updated. Its prediction error would reduce to
+      :math:`\hat{\pi} / \pi - 1`, which the clamp makes non-positive at every step,
+      so the layer would conclude "no volatility" and keep concluding it. That drives
+      :math:`\Omega \to 0`, and without diffusion :math:`\hat{\pi} \to \pi`, so
+      each step's evidence would add to the last and the precision would grow without
+      bound. Leaving the volatility level at its tonic value instead keeps
+      :math:`\Omega` constant, and the precision settles at
+      :math:`1/\Omega + \text{evidence}` — still tracking how well the layer below
+      accounts for the predictors, but bounded.
+    """
+    # Only called for a top element that has a layer below it, so it carries an
+    # incoming matrix.
+    assert parent.weights_in is not None
+    weights = parent.weights_in
+    if parent.add_constant_input:
+        weights = weights[:, :-1]
+
+    precision = jnp.clip(
+        vectorized_posterior_update_precision_value_level(
+            layer=parent.state,
+            child=child_state,
+            weights=weights,
+            coupling_fn=parent.coupling_fn,
+            child_is_input_layer=child_is_input_layer,
+        ),
+        a_min=parent.state.expected_precision,
+        a_max=max_posterior_precision,
+    )
+    new_state = dataclasses.replace(
+        parent.state,
+        precision=precision,
+        value_prediction_error=jnp.zeros_like(precision),
+    )
     return dataclasses.replace(parent, state=new_state)
 
 
@@ -483,6 +553,43 @@ def _set_top_predictors(elem, x):
     return dataclasses.replace(elem, state=new_state)
 
 
+def _sweeps_reach_top(network: Network) -> bool:
+    """Whether both sweeps should treat the top element as a member of the hierarchy.
+
+    Gating the two sweeps on one predicate keeps them in step: a top element that
+    receives a posterior update must also receive the precision prediction that
+    carries it into the next step, or its confidence would accumulate with nothing
+    advancing it.
+
+    Requires ``update_input_layer``, something below the top to send it a message,
+    and a volatile top element — a binary layer's predicted precision is a function
+    of its predicted mean, which is clamped to the predictors here, so there is no
+    precision of its own for the sweeps to move.
+    """
+    return (
+        network.update_input_layer
+        and len(network.layers) > 1
+        and network.layers[-1].kind == "volatile"
+    )
+
+
+def _predict_top_precisions(elem, *, time_step: float):
+    """Predict the top element's precisions, which no parent above it can supply.
+
+    The element's ``expected_mean`` stays clamped to the predictors; what this adds is
+    the predicted precision of both levels, so the confidence the bottom-up sweep wrote
+    into ``precision`` on the previous step is carried forward (damped by the volatility
+    level) instead of being ignored.
+    """
+    new_state = vectorized_root_prediction(
+        layer_state=elem.state,
+        params=elem.params,
+        time_step=time_step,
+        has_volatility_parent=elem.has_volatility_parent,
+    )
+    return dataclasses.replace(elem, state=new_state)
+
+
 def _set_bottom_observations(elem, y):
     """Clamp ``mean`` of the bottom element to the observations ``y``.
 
@@ -584,6 +691,7 @@ def run_scan(
     weight_update: bool,
     record: tuple,
     time_step: float = 1.0,
+    update_confidences: bool = True,
 ) -> tuple:
     r"""Run ``jax.lax.scan`` over the belief-propagation step.
 
@@ -623,6 +731,7 @@ def run_scan(
     the stacked predictions alone (``record == ()``) or a
     ``(stacked_traj, stacked_predictions)`` tuple.
     """
+    template = init_carry[0]
 
     def _scan_body(carry, xs):
         network, opt_state = carry
@@ -635,6 +744,11 @@ def run_scan(
             learning_kind=learning_kind,
             weight_update=weight_update,
         )
+        if not update_confidences:
+            # Static-cascade mode: precisions are parameters, not filter state. Note
+            # that recorded carried fields then show the template values, since the
+            # restore runs before recording.
+            new_network = _restore_confidences(new_network, template)
         if record:
             traj_step = {
                 field: tuple(getattr(elem.state, field) for elem in new_network.layers)
@@ -653,11 +767,17 @@ def _prediction_sweep(
 
     Clamps the predictors on the top element and predicts every element from the one
     above. No prediction errors, posterior updates, or weight learning are performed.
+
+    With ``network.update_input_layer``, the top element also gets its own precision
+    prediction (:func:`_predict_top_precisions`) — the only part of it a parent could
+    have supplied, had there been one.
     """
     elements = list(network.layers)
     n_elements = len(elements)
 
     elements[-1] = _set_top_predictors(elements[-1], x)
+    if _sweeps_reach_top(network):
+        elements[-1] = _predict_top_precisions(elements[-1], time_step=time_step)
 
     for i in range(n_elements - 1, 0, -1):
         elements[i - 1] = _topdown_predict(
@@ -665,6 +785,7 @@ def _prediction_sweep(
             elements[i - 1],
             time_step=time_step,
             precision_clipping_value=network.precision_clipping_value,
+            predict_precision=network.predict_precision,
         )
 
     return dataclasses.replace(network, layers=tuple(elements))
@@ -680,6 +801,12 @@ def _update_sweep(
     element, in bottom-up order. Belief states are updated; inter-layer weights are not.
     The inference time step scales the volatility-level posterior updates with the same
     time step the prediction sweep uses.
+
+    With ``network.update_input_layer``, the sweep also reaches the top element, but
+    on different terms from the interior: its mean stays clamped to the predictors and
+    only its precision moves (see :func:`_top_precision_only`). The top element holds
+    observed inputs that the weight update reads back, so its value is not the
+    network's to revise, only its confidence in that value is.
     """
     elements = list(network.layers)
     n_elements = len(elements)
@@ -702,6 +829,16 @@ def _update_sweep(
             volatility_updates=network.volatility_updates,
             max_posterior_precision=network.max_posterior_precision,
             time_step=time_step,
+        )
+
+    # The top element, when asked for: precision only, mean left on the predictors.
+    if _sweeps_reach_top(network):
+        child_state, _, child_is_input_layer = _child_view(elements[-2])
+        elements[-1] = _top_precision_only(
+            elements[-1],
+            child_state,
+            child_is_input_layer,
+            max_posterior_precision=network.max_posterior_precision,
         )
 
     return dataclasses.replace(network, layers=tuple(elements))
@@ -728,10 +865,7 @@ def update_sweep(network: Network, y: jnp.ndarray, time_step: float = 1.0) -> Ne
 def _input_prediction_error(network: Network) -> jnp.ndarray:
     r"""Prediction error routed to the network's input (top) layer.
 
-    The bottom-up sweep (:func:`_update_sweep`) never touches the top layer:
-    its values are clamped to the predictors ``x``, so it receives no
-    posterior update and no prediction error. This function computes the
-    error message the top layer *would* receive from the layer below it —
+    This is the error message the top layer receives from the layer below it —
     the same gain-weighted prediction error that drives the posterior mean
     shift of every interior layer:
 
@@ -751,6 +885,12 @@ def _input_prediction_error(network: Network) -> jnp.ndarray:
     Because prediction errors follow the ``observed - predicted`` convention,
     the result is the *negative* of the gradient of a squared-error loss with
     respect to the predictors.
+
+    The quantity is the same whether or not the network updates its top layer:
+    it is read off the child, not the top. With ``update_input_layer=True`` the
+    top layer's own ``value_prediction_error`` is this message divided by the
+    top layer's posterior precision — the shift the belief actually made, rather
+    than the raw message that drove it.
 
     Must be called after the update sweep, so the child layer carries its
     posterior prediction error.
@@ -923,6 +1063,26 @@ def apply_confidence_increments(network: Network, increments: tuple) -> Network:
             },
         )
         new_elements.append(dataclasses.replace(elem, state=new_state))
+    return dataclasses.replace(network, layers=tuple(new_elements))
+
+
+def _restore_confidences(network: Network, template: Network) -> Network:
+    """Reset the carried confidence fields to a template's values.
+
+    The inverse of carrying: with this applied after every propagation step, each
+    sample's sweeps still compute full per-sample posteriors but the filtered
+    precisions never become the next sample's starting point.
+    """
+    new_elements = []
+    for elem, ref in zip(network.layers, template.layers):
+        repl = {
+            field: getattr(ref.state, field)
+            for field in _CARRIED_FIELDS
+            if getattr(ref.state, field) is not None
+        }
+        new_elements.append(
+            dataclasses.replace(elem, state=dataclasses.replace(elem.state, **repl))
+        )
     return dataclasses.replace(network, layers=tuple(new_elements))
 
 

--- a/src/model/deep_network.rs
+++ b/src/model/deep_network.rs
@@ -444,10 +444,10 @@ impl DeepNetwork {
     /// One batch-synchronous learning step over many samples at once,
     /// mirroring the JAX `DeepNetwork.batch_update`. Every sample in the
     /// batch is processed from the same state (same weights, same
-    /// confidences); the per-sample weight gradients and confidence changes
+    /// precisions); the per-sample weight gradients and precision changes
     /// are then averaged and applied once, so the whole batch counts as a
     /// single observation. This differs from `fit`, which scans samples
-    /// sequentially and lets the confidences adapt from one sample to the
+    /// sequentially and lets the precisions adapt from one sample to the
     /// next. `optimizer=None` (default) freezes the weights; pass `"adam"` or
     /// Forward phase of the two-phase batch step: predict the batch and keep
     /// the swept states cached, returning the output layer's expected means,
@@ -497,7 +497,7 @@ impl DeepNetwork {
         optimizer = None,
         learning_rate = 1e-3,
         learning_kind = "precision_weighted",
-        update_confidences = true,
+        update_precisions = true,
         time_step = 1.0,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -508,7 +508,7 @@ impl DeepNetwork {
         optimizer: Option<&str>,
         learning_rate: Float,
         learning_kind: &str,
-        update_confidences: bool,
+        update_precisions: bool,
         time_step: Float,
     ) -> PyResult<Py<PyAny>> {
         let opt = optimizer
@@ -554,14 +554,14 @@ impl DeepNetwork {
                     opt_state,
                     time_step,
                     kind,
-                    update_confidences,
+                    update_precisions,
                 )
             })
             .map_err(PyValueError::new_err)?;
         Ok(errors.to_pyarray(py).into_any().unbind())
     }
 
-    /// `"sgd"` with `learning_rate` to learn. `update_confidences=False`
+    /// `"sgd"` with `learning_rate` to learn. `update_precisions=False`
     /// keeps the carried precisions pinned, the setting used for exact
     /// comparisons against backpropagation. Returns the per-sample prediction
     /// errors at the input (top) layer, shape `(n_samples, n_input_features)`;
@@ -572,7 +572,7 @@ impl DeepNetwork {
         optimizer = None,
         learning_rate = 1e-3,
         learning_kind = "precision_weighted",
-        update_confidences = true,
+        update_precisions = true,
         time_step = 1.0,
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -584,7 +584,7 @@ impl DeepNetwork {
         optimizer: Option<&str>,
         learning_rate: Float,
         learning_kind: &str,
-        update_confidences: bool,
+        update_precisions: bool,
         time_step: Float,
     ) -> PyResult<Py<PyAny>> {
         let opt = optimizer
@@ -652,7 +652,7 @@ impl DeepNetwork {
                 opt_state,
                 time_step,
                 kind,
-                update_confidences,
+                update_precisions,
             )
         });
         Ok(errors.to_pyarray(py).into_any().unbind())

--- a/src/model/deep_network.rs
+++ b/src/model/deep_network.rs
@@ -46,6 +46,7 @@ pub struct DeepNetwork {
     volatility_updates: VolatilityUpdate,
     max_posterior_precision: Float,
     precision_clipping_value: Float,
+    predict_precision: bool,
     /// Network-level default coupling function name (validated at
     /// construction).
     default_coupling: String,
@@ -74,6 +75,7 @@ impl DeepNetwork {
             self.volatility_updates,
             self.max_posterior_precision,
             self.precision_clipping_value,
+            self.predict_precision,
         );
         self.net = Some(net);
         self.opt_state = None;
@@ -218,12 +220,14 @@ impl DeepNetwork {
         max_posterior_precision = 1e10,
         precision_clipping_value = 1e-6,
         coupling_fn = "linear",
+        predict_precision = true,
     ))]
     fn py_new(
         volatility_updates: &str,
         max_posterior_precision: Float,
         precision_clipping_value: Float,
         coupling_fn: &str,
+        predict_precision: bool,
     ) -> PyResult<Self> {
         let volatility_updates =
             VolatilityUpdate::parse(volatility_updates).map_err(PyValueError::new_err)?;
@@ -246,6 +250,7 @@ impl DeepNetwork {
             volatility_updates,
             max_posterior_precision,
             precision_clipping_value,
+            predict_precision,
             default_coupling: coupling_fn.to_string(),
         })
     }

--- a/src/updates/vectorised/volatile/prediction.rs
+++ b/src/updates/vectorised/volatile/prediction.rs
@@ -28,6 +28,7 @@ pub fn layer_prediction(
     parent_has_constant: bool,
     has_volatility_parent: bool,
     is_input_layer: bool,
+    predict_precision: bool,
 ) {
     let n = child.mean.len();
     let n_parent = parent.expected_mean.len();
@@ -36,7 +37,7 @@ pub fn layer_prediction(
     // 1. Volatility level (internal); computed into locals, written at the end.
     // Frozen (no volatility parent) → the fields stay as they are (`None`).
     let (expected_mean_vol, expected_precision_vol, effective_precision_vol) =
-        if has_volatility_parent {
+        if has_volatility_parent && predict_precision {
             let mean_vol = child.mean_vol.as_ref().expect("volatility mean");
             let precision_vol = child.precision_vol.as_ref().expect("volatility precision");
 
@@ -90,7 +91,7 @@ pub fn layer_prediction(
     // Predicted volatility Ω = t·exp(μ_vol + 1/(2·π̂_vol)), fused. The volatility
     // coupling is fixed at 1 and the value level carries no tonic volatility of
     // its own.
-    let predicted_vol = if has_volatility_parent {
+    let predicted_vol = if has_volatility_parent && predict_precision {
         let emv = expected_mean_vol.as_ref().unwrap();
         let epv = expected_precision_vol.as_ref().unwrap();
         ndarray::Zip::from(emv)
@@ -116,8 +117,11 @@ pub fn layer_prediction(
     }
 
     // Conditional (π̂) and marginal (π̃) predicted precisions, written in place.
-    if is_input_layer {
-        // Input/leaf override: no random walk between observations.
+    if is_input_layer || !predict_precision {
+        // Input/leaf override, and the same treatment when precision prediction
+        // is switched off network-wide: no random walk between observations, no
+        // parent-uncertainty bleed-through, nothing carried into the
+        // volatility-coupling posterior update.
         let prior = child.precision.clone();
         child.conditional_expected_precision.assign(&prior);
         child.expected_precision.assign(&prior);
@@ -177,6 +181,7 @@ mod tests {
             false,
             true,
             false,
+            true,
         );
         // rows: [1,0]·[1,2]=1, [0,1]·[1,2]=2, [1,1]·[1,2]=3
         assert!((child.expected_mean[0] - 1.0).abs() < 1e-12);
@@ -204,6 +209,7 @@ mod tests {
             true,
             true,
             false,
+            true,
         );
         // 3*2 + 5*1 = 11
         assert!((child.expected_mean[0] - 11.0).abs() < 1e-12);
@@ -229,9 +235,44 @@ mod tests {
             false,
             true,
             true, // is_input_layer
+            true,
         );
         assert_eq!(child.expected_precision, prior_precision);
         assert_eq!(child.conditional_expected_precision, prior_precision);
         assert!(child.effective_precision.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn test_predict_precision_false_freezes_the_precisions() {
+        // Same freeze as the input-layer override, but asked for network-wide on
+        // an ordinary interior layer, and the volatility level is left alone too.
+        let parent = LayerState::create(2, true);
+        let mut child = LayerState::create(3, true);
+        let child_params = LayerParams::create(3);
+        let weights = Matrix::from_shape_vec((3, 2), vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0]).unwrap();
+        let prior_precision = child.precision.clone();
+        let prior_mean_vol = child.mean_vol.clone().unwrap();
+
+        layer_prediction(
+            &mut child,
+            &child_params,
+            &parent,
+            &weights,
+            linear(),
+            1.0,
+            false,
+            true,  // has_volatility_parent
+            false, // is_input_layer
+            false, // predict_precision
+        );
+
+        assert_eq!(child.expected_precision, prior_precision);
+        assert_eq!(child.conditional_expected_precision, prior_precision);
+        assert!(child.effective_precision.iter().all(|&x| x == 0.0));
+        // The volatility level is untouched.
+        assert_eq!(child.mean_vol.unwrap(), prior_mean_vol);
+        // The mean is still predicted: [1,0]·[0,0] etc. all zero here, but the
+        // field is written rather than left at its previous value.
+        assert_eq!(child.expected_mean.len(), 3);
     }
 }

--- a/src/vectorised/batched.rs
+++ b/src/vectorised/batched.rs
@@ -771,17 +771,17 @@ pub fn batched_mean_weight_gradients(
     grads
 }
 
-/// Per-layer batch-mean increments of the carried confidence fields: the
+/// Per-layer batch-mean increments of the carried precision fields: the
 /// value-level posterior precision and, where present, the volatility
 /// level's belief `(mean_vol, precision_vol)`.
-pub type ConfidenceIncrements = Vec<(Vector, Option<(Vector, Vector)>)>;
+pub type PrecisionIncrements = Vec<(Vector, Option<(Vector, Vector)>)>;
 
-/// Batch-mean increments of the carried confidence fields relative to the
+/// Batch-mean increments of the carried precision fields relative to the
 /// template: `row_mean(field) − template`, per layer.
-pub fn batched_confidence_increments(
+pub fn batched_precision_increments(
     states: &[BatchedLayerState],
     templates: &[&LayerState],
-) -> ConfidenceIncrements {
+) -> PrecisionIncrements {
     states
         .iter()
         .zip(templates.iter())

--- a/src/vectorised/layer.rs
+++ b/src/vectorised/layer.rs
@@ -330,6 +330,11 @@ pub struct DeepNet {
     pub max_posterior_precision: Float,
     /// Lower/upper clamp bounding binary predictions away from 0 and 1.
     pub precision_clipping_value: Float,
+    /// Whether the prediction sweep advances the precisions. With `false` every
+    /// layer's predicted precisions are held at its prior precision, its
+    /// effective precision is zero and its volatility level is left untouched,
+    /// so prediction produces only the expected means.
+    pub predict_precision: bool,
 }
 
 impl DeepNet {
@@ -414,6 +419,7 @@ impl DeepNet {
             volatility_updates: VolatilityUpdate::Unbounded,
             max_posterior_precision: 1e10,
             precision_clipping_value: 1e-6,
+            predict_precision: true,
         })
     }
 
@@ -423,10 +429,12 @@ impl DeepNet {
         volatility_updates: VolatilityUpdate,
         max_posterior_precision: Float,
         precision_clipping_value: Float,
+        predict_precision: bool,
     ) -> Self {
         self.volatility_updates = volatility_updates;
         self.max_posterior_precision = max_posterior_precision;
         self.precision_clipping_value = precision_clipping_value;
+        self.predict_precision = predict_precision;
         self
     }
 

--- a/src/vectorised/network.rs
+++ b/src/vectorised/network.rs
@@ -30,6 +30,7 @@ fn predict_child(
     weights: &Matrix,
     time_step: Float,
     pcv: Float,
+    predict_precision: bool,
 ) {
     match child.kind {
         LayerKind::Volatile => volatile::prediction::layer_prediction(
@@ -42,6 +43,7 @@ fn predict_child(
             parent.add_constant_input,
             child.has_volatility_parent,
             child.is_input_layer,
+            predict_precision,
         ),
         LayerKind::Binary => binary::prediction::binary_prediction(
             &mut child.state,
@@ -136,12 +138,13 @@ impl DeepNet {
         let n = self.layers.len();
         self.set_top_predictors(x);
         let pcv = self.precision_clipping_value;
+        let predict_precision = self.predict_precision;
         for i in (1..n).rev() {
             let (lower, upper) = self.layers.split_at_mut(i);
             let child = &mut lower[i - 1];
             let parent = &upper[0];
             let weights = parent.weights_in.as_ref().expect("parent has no weights");
-            predict_child(child, parent, weights, time_step, pcv);
+            predict_child(child, parent, weights, time_step, pcv, predict_precision);
         }
     }
 

--- a/src/vectorised/network.rs
+++ b/src/vectorised/network.rs
@@ -91,7 +91,7 @@ struct ChunkOut {
     range: std::ops::Range<usize>,
     errors: Matrix,
     grads: Option<Vec<Option<Matrix>>>,
-    increments: Option<crate::vectorised::batched::ConfidenceIncrements>,
+    increments: Option<crate::vectorised::batched::PrecisionIncrements>,
 }
 
 /// Chunk count of a batched call: per-thread slabs, small batches staying in
@@ -285,17 +285,17 @@ impl DeepNet {
     /// mirroring the JAX `batch_step`.
     ///
     /// Every sample is processed from the same state template (same weights,
-    /// same confidences); the whole batch is swept together through the
+    /// same precisions); the whole batch is swept together through the
     /// batched kernels of [`crate::vectorised::batched`], so every phase is
     /// one `gemm` per layer in a features × samples layout. The per-sample
-    /// weight gradients and confidence changes are averaged and applied once,
+    /// weight gradients and precision changes are averaged and applied once,
     /// so the whole batch counts as a single observation. This differs from
-    /// [`Self::propagation_step`] driven sequentially, where the confidences
+    /// [`Self::propagation_step`] driven sequentially, where the precisions
     /// adapt from one sample to the next.
     ///
     /// With `optimizer` set, the batch-mean descent gradient drives one
     /// optimiser step; with `None` the weights are frozen. With
-    /// `update_confidences`, the batch-mean change of the carried confidence
+    /// `update_precisions`, the batch-mean change of the carried precision
     /// fields (the value-level posterior precision and the volatility level's
     /// belief) is added to the template state; everything else is left on the
     /// template, as the next batch's sweeps rewrite it anyway.
@@ -312,7 +312,7 @@ impl DeepNet {
         opt_state: Option<&mut OptState>,
         time_step: Float,
         learning_kind: WeightKind,
-        update_confidences: bool,
+        update_precisions: bool,
     ) -> Matrix {
         self.batch_update_with_workspace(
             &mut crate::vectorised::batched::BatchWorkspace::default(),
@@ -322,7 +322,7 @@ impl DeepNet {
             opt_state,
             time_step,
             learning_kind,
-            update_confidences,
+            update_precisions,
         )
     }
 
@@ -341,7 +341,7 @@ impl DeepNet {
         opt_state: Option<&mut OptState>,
         time_step: Float,
         learning_kind: WeightKind,
-        update_confidences: bool,
+        update_precisions: bool,
     ) -> Matrix {
         // Samples are exchangeable by construction, so the batch splits into
         // per-thread slabs swept independently; small batches stay in one
@@ -355,7 +355,7 @@ impl DeepNet {
             opt_state,
             time_step,
             learning_kind,
-            update_confidences,
+            update_precisions,
             n_chunks,
         )
     }
@@ -363,7 +363,7 @@ impl DeepNet {
     /// The chunked executor behind [`Self::batch_update`]: sweep each slab of
     /// samples through the batched kernels in parallel, then combine the
     /// per-chunk results (input-error slices concatenated; gradient and
-    /// confidence means weighted by chunk size) and apply them once.
+    /// precision means weighted by chunk size) and apply them once.
     #[allow(clippy::too_many_arguments)]
     fn batch_update_chunked(
         &mut self,
@@ -374,11 +374,11 @@ impl DeepNet {
         opt_state: Option<&mut OptState>,
         time_step: Float,
         learning_kind: WeightKind,
-        update_confidences: bool,
+        update_precisions: bool,
         n_chunks: usize,
     ) -> Matrix {
         use crate::vectorised::batched::{
-            batched_confidence_increments, batched_input_prediction_error,
+            batched_precision_increments, batched_input_prediction_error,
             batched_mean_weight_gradients, batched_prediction_sweep, batched_update_sweep,
             reset_chunk,
         };
@@ -407,7 +407,7 @@ impl DeepNet {
                 let grads =
                     learning.then(|| batched_mean_weight_gradients(net, states, learning_kind));
                 let increments =
-                    update_confidences.then(|| batched_confidence_increments(states, &templates));
+                    update_precisions.then(|| batched_precision_increments(states, &templates));
                 ChunkOut {
                     range,
                     errors,
@@ -422,7 +422,7 @@ impl DeepNet {
             n_samples,
             optimizer,
             opt_state,
-            update_confidences,
+            update_precisions,
         )
     }
 
@@ -484,10 +484,10 @@ impl DeepNet {
         opt_state: Option<&mut OptState>,
         time_step: Float,
         learning_kind: WeightKind,
-        update_confidences: bool,
+        update_precisions: bool,
     ) -> Result<Matrix, String> {
         use crate::vectorised::batched::{
-            batched_confidence_increments, batched_input_prediction_error,
+            batched_precision_increments, batched_input_prediction_error,
             batched_mean_weight_gradients, batched_update_sweep,
         };
         use crate::vectorised::layer::LayerState;
@@ -541,7 +541,7 @@ impl DeepNet {
                 let grads =
                     learning.then(|| batched_mean_weight_gradients(net, states, learning_kind));
                 let increments =
-                    update_confidences.then(|| batched_confidence_increments(states, &templates));
+                    update_precisions.then(|| batched_precision_increments(states, &templates));
                 ChunkOut {
                     range,
                     errors,
@@ -556,13 +556,13 @@ impl DeepNet {
             n_samples,
             optimizer,
             opt_state,
-            update_confidences,
+            update_precisions,
         ))
     }
 
     /// Combine per-chunk outputs (input-error slices concatenated; gradient
-    /// and confidence means weighted by chunk size) and apply the optimiser
-    /// step and confidence increments once. Returns the routed input errors,
+    /// and precision means weighted by chunk size) and apply the optimiser
+    /// step and precision increments once. Returns the routed input errors,
     /// `(top_size, n_samples)`, transposed to samples-first at the return.
     fn combine_and_apply(
         &mut self,
@@ -570,7 +570,7 @@ impl DeepNet {
         n_samples: usize,
         optimizer: Option<&Optimizer>,
         opt_state: Option<&mut OptState>,
-        update_confidences: bool,
+        update_precisions: bool,
     ) -> Matrix {
         let top_size = self.layers[self.layers.len() - 1].n_nodes();
         let mut input_errors = Matrix::zeros((top_size, n_samples));
@@ -603,7 +603,7 @@ impl DeepNet {
             opt.apply_dense(state, &mut self.layers, &grads);
         }
 
-        if update_confidences {
+        if update_precisions {
             for (l, layer) in self.layers.iter_mut().enumerate() {
                 for chunk in &chunk_outs {
                     let weight = chunk.range.len() as Float / n_samples as Float;
@@ -790,7 +790,7 @@ mod tests {
     /// each sample from the template with the per-sample kernels, averaging
     /// the rank-one gradients and the carried-field increments, and applying
     /// both once. Covers a three-layer network with a nonlinear (tanh)
-    /// coupling, Adam, and confidence carrying.
+    /// coupling, Adam, and precision carrying.
     #[test]
     fn test_batch_update_matches_per_sample_reference() {
         use crate::math::resolve_coupling_fn;

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -1165,3 +1165,309 @@ def test_batch_update_from_predicted_states_matches():
         rtol=1e-6,
         atol=1e-7,
     )
+
+
+# ---------------------------------------------------------------------------
+# ``update_input_layer``: the sweeps reaching the top (input) layer
+# ---------------------------------------------------------------------------
+
+
+def _three_layer(update_input_layer):
+    """Build a 2 -> 4 -> 2 network, identical apart from the flag under test."""
+    net = DeepNetwork(update_input_layer=update_input_layer)
+    return (
+        net
+        .add_layer(size=2, add_constant_input=False)
+        .add_layer(size=4, add_constant_input=False)
+        .add_layer(size=2, add_constant_input=False)
+    )
+
+
+def test_input_layer_frozen_by_default():
+    """Off (the default), no sweep writes anything to the top layer.
+
+    This is the behaviour the Rust backend and the nodalised ``Network`` share, so it
+    has to survive the flag being added.
+    """
+    net = _three_layer(False)
+    before = net.state.layers[-1].state
+    net.prediction(jnp.array([1.0, -1.0])).update(jnp.array([0.5, 0.5]))
+    after = net.state.layers[-1].state
+
+    for field in ("precision", "expected_precision", "mean_vol", "precision_vol"):
+        np.testing.assert_array_equal(
+            getattr(after, field), getattr(before, field), err_msg=field
+        )
+    # Only the clamp itself moved: mean and expected_mean are the predictors.
+    np.testing.assert_array_equal(after.mean, jnp.array([1.0, -1.0]))
+    np.testing.assert_array_equal(after.value_prediction_error, jnp.zeros(2))
+
+
+def test_input_layer_precision_moves_but_mean_stays_on_the_predictors():
+    """On, only the top layer's confidence moves — its value stays on the input.
+
+    The predictors are observed, and the weight update reads the top layer's mean back
+    to build its parent-side factor, so that mean is not the network's to revise. Its
+    precision is.
+    """
+    x = jnp.array([1.0, -1.0])
+    net = _three_layer(True)
+    net.prediction(x).update(jnp.array([0.5, 0.5]))
+    top = net.state.layers[-1].state
+
+    np.testing.assert_array_equal(top.expected_mean, x)
+    np.testing.assert_array_equal(top.mean, x)
+    # A layer pinned to its own prediction has no residual.
+    np.testing.assert_array_equal(top.value_prediction_error, jnp.zeros(2))
+    # Evidence arrived, so the belief sharpened past its own prediction.
+    assert np.all(np.asarray(top.precision) > np.asarray(top.expected_precision))
+
+
+def test_input_layer_weight_gradient_sees_the_clamped_predictors():
+    """The top weight matrix is learned against the inputs that were supplied.
+
+    The parent-side factor of the gradient is ``coupling_fn(parent.mean)``, so a top
+    layer whose mean drifted off ``x`` would train its weights against an estimate of
+    the input rather than the input. Turning the flag on must not change that factor.
+    """
+    rng = np.random.default_rng(3)
+    w = rng.normal(size=(4, 2))
+    x = jnp.asarray(rng.normal(size=(2,)))
+    y = jnp.asarray(rng.normal(size=(2,)))
+
+    grads = []
+    for flag in (False, True):
+        net = _three_layer(flag)
+        _set_weights(net, {1: np.eye(2, 4), 2: w})
+        before = np.asarray(net.state.layers[-1].weights_in).copy()
+        net.prediction(x).update(y, optimizer=optax.sgd(1e-2))
+        grads.append(np.asarray(net.state.layers[-1].weights_in) - before)
+
+    # Same parent activation, same child error on this first step: same update.
+    np.testing.assert_allclose(grads[0], grads[1], rtol=1e-6, atol=1e-7)
+
+
+def test_input_layer_precision_equilibrates_instead_of_running_away():
+    """The clamped top layer's precision settles rather than growing without bound.
+
+    Its volatility level is deliberately not updated: with the mean clamped the
+    volatility prediction error can never be positive, so a layer that did update it
+    would drive its own diffusion to zero and then accumulate evidence forever. Held
+    at the tonic value, the diffusion bounds the precision.
+    """
+    x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
+    net = _three_layer(True)
+
+    seen = []
+    for step in range(400):
+        net.prediction(x).update(y)
+        if step in (0, 199, 399):
+            seen.append(
+                float(np.mean(np.asarray(net.state.layers[-1].state.precision)))
+            )
+
+    early, mid, late = seen
+    assert early < mid  # evidence sharpens it ...
+    assert np.isfinite(late)
+    assert abs(late - mid) < 0.01 * mid  # ... then it settles
+    # The volatility level was never touched, which is what supplies the ceiling.
+    top = net.state.layers[-1].state
+    np.testing.assert_array_equal(top.mean_vol, jnp.zeros(2))
+    np.testing.assert_array_equal(top.precision_vol, jnp.ones(2))
+
+
+def test_input_layer_posterior_precision_is_carried_to_the_next_prediction():
+    """The posterior precision written on one step shapes the next step's prediction.
+
+    This is the whole point of the flag: without the carry, ``expected_precision``
+    at the top is a constant, and the layer below inherits a constant value-coupling
+    variance no matter how much evidence has accumulated.
+    """
+    x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
+    net = _three_layer(True)
+
+    net.prediction(x).update(y)
+    first = np.asarray(net.state.layers[-1].state.precision).copy()
+    hidden_first = np.asarray(net.state.layers[1].state.expected_precision).copy()
+
+    for _ in range(20):
+        net.prediction(x).update(y)
+    later = np.asarray(net.state.layers[-1].state.precision)
+
+    assert np.all(later > first)
+    # A more precise input bleeds less uncertainty into the layer below, so that
+    # layer's own predicted precision rises with it.
+    assert np.all(
+        np.asarray(net.state.layers[1].state.expected_precision) > hidden_first
+    )
+
+
+def test_input_layer_flag_survives_from_dict():
+    """The flag is part of the network spec, not just the constructor."""
+    config = {
+        "layers": [{"size": 2}, {"size": 3}],
+        "update_input_layer": True,
+    }
+    assert DeepNetwork.from_dict(config).state.update_input_layer is True
+    assert (
+        DeepNetwork.from_dict({"layers": [{"size": 2}]}).state.update_input_layer
+        is False
+    )
+
+
+def test_input_layer_updated_under_batch_and_scan():
+    """``fit`` and ``batch_update`` route through the same sweeps as ``update``.
+
+    Both carry the top layer's confidence forward (it is one of ``_CARRIED_FIELDS``), so
+    neither should leave it at the value ``add_layer`` gave it.
+    """
+    rng = np.random.default_rng(0)
+    x = jnp.asarray(rng.normal(size=(16, 2)))
+    y = jnp.asarray(rng.normal(size=(16, 2)))
+
+    for net in (
+        _three_layer(True).fit(
+            x, y, optimizer=optax.sgd(1e-3), learning_kind="standard"
+        ),
+        _three_layer(True).batch_update(
+            x, y, optimizer=optax.sgd(1e-3), learning_kind="standard"
+        ),
+    ):
+        precision = np.asarray(net.state.layers[-1].state.precision)
+        assert np.all(np.isfinite(precision))
+        assert not np.allclose(precision, 1.0)
+
+
+def test_input_layer_precision_tracks_the_routed_evidence_not_the_residual():
+    """The clamped input's precision follows the connection, not the fit."""
+    rng = np.random.default_rng(7)
+    w = rng.normal(size=(2, 2))
+    x = jnp.asarray(rng.normal(size=(200, 2)))
+
+    def settle(y, weights):
+        net = (
+            DeepNetwork(update_input_layer=True)
+            .add_layer(size=2, add_constant_input=False)
+            .add_layer(size=2, add_constant_input=False)
+        )
+        _set_weights(net, {1: weights})
+        # Weights frozen, so nothing but the beliefs can move.
+        net.fit(x, y, optimizer=optax.sgd(0.0), weight_update=False)
+        return float(np.mean(np.asarray(net.state.layers[-1].state.precision)))
+
+    explained = settle(jnp.asarray(np.asarray(x) @ w.T), w)
+    noise = settle(jnp.asarray(rng.normal(size=(200, 2))), w)
+    assert explained == pytest.approx(noise, rel=1e-6)
+
+    stronger = settle(jnp.asarray(np.asarray(x) @ w.T), 2.0 * w)
+    assert stronger > explained
+
+
+# ---------------------------------------------------------------------------
+# ``predict_precision``: the precision-prediction switch
+# ---------------------------------------------------------------------------
+
+
+def _precision_net(predict_precision, volatility_parent=True):
+    """Build a 2 -> 2 -> 2 chain whose interior layer imports parent uncertainty."""
+    net = DeepNetwork(
+        coupling_fn=jax.nn.leaky_relu, predict_precision=predict_precision
+    )
+    for _ in range(3):
+        net.add_layer(
+            size=2, add_constant_input=False, volatility_parent=volatility_parent
+        )
+    return net
+
+
+def test_predict_precision_false_freezes_every_predicted_precision():
+    """With the flag off, prediction produces means and leaves precisions alone."""
+    x = jnp.array([0.7, -0.4])
+    frozen = _precision_net(False).prediction(x)
+
+    for layer in frozen.state.layers:
+        state = layer.state
+        np.testing.assert_allclose(state.expected_precision, state.precision, rtol=1e-6)
+        np.testing.assert_allclose(
+            state.conditional_expected_precision, state.precision, rtol=1e-6
+        )
+        np.testing.assert_allclose(state.effective_precision, 0.0, atol=0.0)
+
+
+def test_predict_precision_false_leaves_the_volatility_level_untouched():
+    """The volatility level is not advanced when the value precisions are frozen."""
+    x = jnp.array([0.7, -0.4])
+    net = _precision_net(False)
+    before = [np.asarray(layer.state.mean_vol).copy() for layer in net.state.layers]
+    after = net.prediction(x).state.layers
+
+    for start, layer in zip(before, after):
+        np.testing.assert_array_equal(np.asarray(layer.state.expected_mean_vol), start)
+        np.testing.assert_array_equal(
+            np.asarray(layer.state.expected_precision_vol),
+            np.asarray(layer.state.precision_vol),
+        )
+
+
+def test_predict_precision_does_not_touch_the_predicted_means():
+    """The flag governs precisions only; the expected means are identical."""
+    x = jnp.array([0.7, -0.4])
+    on = _precision_net(True).prediction(x).state.layers
+    off = _precision_net(False).prediction(x).state.layers
+    for a, b in zip(on, off):
+        np.testing.assert_allclose(
+            np.asarray(a.state.expected_mean),
+            np.asarray(b.state.expected_mean),
+            rtol=1e-6,
+        )
+
+
+def test_predict_precision_default_is_on():
+    """The default is the ordinary filter, in which precisions do move."""
+    x = jnp.array([0.7, -0.4])
+    net = DeepNetwork(coupling_fn=jax.nn.leaky_relu)
+    assert net.predict_precision is True
+    interior = _precision_net(True).prediction(x).state.layers[1].state
+    # The volatility diffusion alone lowers the predicted precision below the prior.
+    assert np.all(
+        np.asarray(interior.conditional_expected_precision)
+        < np.asarray(interior.precision)
+    )
+
+
+def test_fit_update_confidences_false_pins_precisions():
+    """Static-cascade mode: precisions stay at their built values across a fit."""
+    rng = np.random.default_rng(0)
+    x = jnp.asarray(rng.normal(size=(32, 2)))
+    y = jnp.asarray(rng.normal(size=(32, 2)))
+
+    def build():
+        return (
+            DeepNetwork(coupling_fn=jax.nn.leaky_relu)
+            .add_layer(size=2, add_constant_input=False, volatility_parent=False)
+            .add_layer(
+                size=4,
+                add_constant_input=False,
+                volatility_parent=False,
+                precision=3.0,
+            )
+            .add_layer(size=2, add_constant_input=False, volatility_parent=False)
+        )
+
+    static = build()
+    before = np.asarray(static.state.layers[1].weights_in).copy()
+    static.fit(
+        x,
+        y,
+        optimizer=optax.sgd(1e-2),
+        learning_kind="standard",
+        update_confidences=False,
+    )
+    np.testing.assert_array_equal(
+        static.state.layers[1].state.precision, jnp.full(4, 3.0)
+    )
+    assert not np.allclose(np.asarray(static.state.layers[1].weights_in), before)
+
+    # The default carries, so the two modes genuinely diverge.
+    dynamic = build().fit(x, y, optimizer=optax.sgd(1e-2), learning_kind="standard")
+    assert not np.allclose(np.asarray(dynamic.state.layers[1].state.precision), 3.0)

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -1422,6 +1422,74 @@ def test_predict_precision_does_not_touch_the_predicted_means():
         )
 
 
+def test_predict_precision_false_freezes_the_clamped_top_layer():
+    """The two flags compose: a swept top layer still gets no precision prediction.
+
+    ``update_input_layer`` is what routes the top element through
+    :func:`~pyhgf.updates.vectorized.volatile.vectorized_root_prediction` — it is the
+    only layer with no parent above to predict it. With ``predict_precision`` off that
+    root prediction has to freeze exactly as an interior layer does, or the top would
+    keep diffusing while the rest of the hierarchy stood still.
+    """
+    x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
+
+    def top_after_a_step(predict_precision):
+        net = DeepNetwork(update_input_layer=True, predict_precision=predict_precision)
+        for size in (2, 4, 2):
+            net.add_layer(size=size, add_constant_input=False)
+        net.prediction(x).update(y)
+        # A second step, so the prediction reads a posterior precision the previous
+        # step wrote rather than the value ``add_layer`` built.
+        return net.prediction(x).state.layers[-1].state
+
+    frozen = top_after_a_step(False)
+    np.testing.assert_allclose(frozen.expected_precision, frozen.precision, rtol=1e-6)
+    np.testing.assert_allclose(
+        frozen.conditional_expected_precision, frozen.precision, rtol=1e-6
+    )
+    np.testing.assert_allclose(frozen.effective_precision, 0.0, atol=0.0)
+    # The volatility level is not advanced either.
+    np.testing.assert_array_equal(frozen.expected_mean_vol, frozen.mean_vol)
+    np.testing.assert_array_equal(frozen.expected_precision_vol, frozen.precision_vol)
+
+    # With the prediction on, the diffusion damps the carried precision instead.
+    live = top_after_a_step(True)
+    assert np.all(np.asarray(live.expected_precision) < np.asarray(live.precision))
+
+
+def test_input_layer_precision_ignores_the_constant_node():
+    """A constant input node carries no evidence about the predictors' precision.
+
+    ``_top_precision_only`` drops the bias column before reading the routed evidence:
+    the constant node is not a belief the network holds about the input, so its weights
+    say nothing about how precise the observed predictors are. Its column is also what
+    makes ``weights_in`` one wider than the top layer's own precision, so leaving it in
+    would not even be shape-compatible.
+    """
+    x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
+    rng = np.random.default_rng(11)
+    body = rng.normal(size=(4, 2))
+
+    def settle(bias_column):
+        net = DeepNetwork(update_input_layer=True)
+        net.add_layer(size=2, add_constant_input=False)
+        net.add_layer(size=4, add_constant_input=False)
+        net.add_layer(size=2, add_constant_input=bias_column is not None)
+        if bias_column is None:
+            _set_weights(net, {2: body})
+        else:
+            _set_weights(net, {2: np.hstack([body, bias_column[:, None]])})
+        net.prediction(x).update(y)
+        return np.asarray(net.state.layers[-1].state.precision)
+
+    plain = settle(None)
+    # The top layer keeps its own node count; the constant lives in the matrix only.
+    assert plain.shape == (2,)
+    np.testing.assert_allclose(settle(np.zeros(4)), plain, rtol=1e-6)
+    # An enormous constant weight is still not evidence about the input.
+    np.testing.assert_allclose(settle(np.full(4, 50.0)), plain, rtol=1e-6)
+
+
 def test_predict_precision_default_is_on():
     """The default is the ordinary filter, in which precisions do move."""
     x = jnp.array([0.7, -0.4])

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -821,7 +821,7 @@ def test_input_error_routes_child_error_through_weights():
     """``input_error()`` returns the child's error routed back through the weights.
 
     Two linear layers without bias and with default (unit) precisions: the
-    confidence weighting is 1, so the message at the input (top) layer reduces
+    precision weighting is 1, so the message at the input (top) layer reduces
     to ``W.T @ (y - W @ x)`` — the output residual multiplied back through the
     connecting weight matrix.
     """
@@ -880,7 +880,7 @@ def test_ff_block_single_sweep_matches_backprop():
 
     The network is configured so that the single belief-propagation sweep
     reproduces the gradients of a squared-error loss on the identical forward
-    function: volatility levels frozen, high prior precision (confidence) on
+    function: volatility levels frozen, high prior precision on
     the hidden and input layers so their beliefs barely move during the update
     sweep, unit precision on the observed output layer, and the
     ``"precision_weighted"`` learning mode — the hidden layer's belief shift is
@@ -902,14 +902,14 @@ def test_ff_block_single_sweep_matches_backprop():
 
     g_w1, g_w2, g_x = _ff_oracle_grads(w1, w2, x, y)
 
-    high_confidence = dict(
+    high_precision = dict(
         volatility_parent=False,
         precision=1e4,
         expected_precision=1e4,
     )
     net = _ff_net(
-        hidden_kwargs=high_confidence,
-        top_kwargs=high_confidence,
+        hidden_kwargs=high_precision,
+        top_kwargs=high_precision,
         leaf_kwargs=dict(volatility_parent=False),
     )
     _set_weights(net, {1: w1, 2: w2})
@@ -973,7 +973,7 @@ def test_sample_step_matches_stateful_api():
 
     From the same state template, ``sample_step`` must return (a) the same input-layer
     error as ``net.prediction(x).update(y)`` followed by ``input_error()``, (b)
-    confidence increments equal to the change of the carried fields (value precision and
+    precision increments equal to the change of the carried fields (value precision and
     the volatility level), and (c) weight gradients matching the weight change one SGD
     step applies.
     """
@@ -988,7 +988,7 @@ def test_sample_step_matches_stateful_api():
 
     input_error, grads, increments = sample_step(template, x, y)
 
-    # Beliefs-only stateful pass: input error and confidence increments.
+    # Beliefs-only stateful pass: input error and precision increments.
     net.prediction(x).update(y)
     np.testing.assert_allclose(input_error, net.input_error(), rtol=1e-5, atol=1e-7)
     for elem_before, elem_after, inc in zip(
@@ -1022,7 +1022,7 @@ def test_batch_update_averages_and_is_batch_size_invariant():
     """A batch counts as one observation: averaged updates, repetition-invariant.
 
     ``batch_update`` must apply the batch-mean of the per-sample weight gradients in one
-    optimiser step, advance the confidence state by the batch-mean of the per-sample
+    optimiser step, advance the precision state by the batch-mean of the per-sample
     increments, and return per-sample input errors matching the pure per-sample step.
     Feeding the same batch twice over must produce the same step.
     """
@@ -1087,21 +1087,21 @@ def test_batch_update_averages_and_is_batch_size_invariant():
 
 
 def test_batch_update_freezing_flags():
-    """``update_confidences=False`` and ``optimizer=None`` freeze their targets.
+    """``update_precisions=False`` and ``optimizer=None`` freeze their targets.
 
-    Without confidence updates, the carried fields stay exactly at their template values
+    Without precision updates, the carried fields stay exactly at their template values
     while the weights still learn (the mode used for exact comparisons against
     backpropagation). Without an optimiser, the weights stay exactly fixed while the
-    confidences still adapt.
+    precisions still adapt.
     """
     rng = np.random.default_rng(31)
     xb = jnp.asarray(rng.normal(size=(4, _FF_D)))
     yb = jnp.asarray(rng.normal(size=(4, _FF_D)))
 
-    # Confidences frozen, weights learning.
+    # Precisions frozen, weights learning.
     net, w1, w2 = _ff_net_with_weights(rng)
     template = net.state
-    net.batch_update(xb, yb, optimizer=optax.sgd(1e-2), update_confidences=False)
+    net.batch_update(xb, yb, optimizer=optax.sgd(1e-2), update_precisions=False)
     for elem_before, elem_after in zip(template.layers, net.state.layers):
         for field in ("precision", "mean_vol", "precision_vol"):
             np.testing.assert_array_equal(
@@ -1109,7 +1109,7 @@ def test_batch_update_freezing_flags():
             )
     assert not np.allclose(net.state.layers[1].weights_in, w1)
 
-    # Weights frozen, confidences adapting.
+    # Weights frozen, precisions adapting.
     net_frozen = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
     _set_weights(net_frozen, {1: w1, 2: w2})
     template_frozen = net_frozen.state
@@ -1204,7 +1204,7 @@ def test_input_layer_frozen_by_default():
 
 
 def test_input_layer_precision_moves_but_mean_stays_on_the_predictors():
-    """On, only the top layer's confidence moves — its value stays on the input.
+    """On, only the top layer's precision moves — its value stays on the input.
 
     The predictors are observed, and the weight update reads the top layer's mean back
     to build its parent-side factor, so that mean is not the network's to revise. Its
@@ -1318,7 +1318,7 @@ def test_input_layer_flag_survives_from_dict():
 def test_input_layer_updated_under_batch_and_scan():
     """``fit`` and ``batch_update`` route through the same sweeps as ``update``.
 
-    Both carry the top layer's confidence forward (it is one of ``_CARRIED_FIELDS``), so
+    Both carry the top layer's precision forward (it is one of ``_CARRIED_FIELDS``), so
     neither should leave it at the value ``add_layer`` gave it.
     """
     rng = np.random.default_rng(0)
@@ -1435,7 +1435,7 @@ def test_predict_precision_default_is_on():
     )
 
 
-def test_fit_update_confidences_false_pins_precisions():
+def test_fit_update_precisions_false_pins_precisions():
     """Static-cascade mode: precisions stay at their built values across a fit."""
     rng = np.random.default_rng(0)
     x = jnp.asarray(rng.normal(size=(32, 2)))
@@ -1461,7 +1461,7 @@ def test_fit_update_confidences_false_pins_precisions():
         y,
         optimizer=optax.sgd(1e-2),
         learning_kind="standard",
-        update_confidences=False,
+        update_precisions=False,
     )
     np.testing.assert_array_equal(
         static.state.layers[1].state.precision, jnp.full(4, 3.0)

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -88,24 +88,24 @@ def test_fused_adapter_tracks_backprop_twin():
         assert _norm_rel(input_error, per_sample_dx) < 1e-2, f"step {step}"
 
 
-def test_fused_confidences_carry_across_steps():
-    """Released confidences adapt across steps; pinned ones stay put."""
+def test_fused_precisions_carry_across_steps():
+    """Released precisions adapt across steps; pinned ones stay put."""
     rng = np.random.default_rng(2)
     k1, k2 = random.split(random.key(3))
     fc1 = eqx.nn.Linear(6, 12, key=k1)
     fc2 = eqx.nn.Linear(12, 6, key=k2)
 
-    def run(update_confidences):
-        leaf = _PARITY_LEAF if not update_confidences else {}
+    def run(update_precisions):
+        leaf = _PARITY_LEAF if not update_precisions else {}
         layer = (
             _PARITY
-            if not update_confidences
+            if not update_precisions
             else dict(precision=30.0, expected_precision=30.0)
         )
         part = DeepNetworkAdapter(
             from_feedforward(fc1, fc2, leaf_kwargs=leaf, layer_kwargs=layer),
             optimizer=optax.adam(1e-3),
-            update_confidences=update_confidences,
+            update_precisions=update_precisions,
         )
         fused = FusedPipeline(part)
         # Snapshot, not a live reference: the step donates the state buffers.
@@ -117,9 +117,9 @@ def test_fused_confidences_carry_across_steps():
             )
         return before, fused.state[0].layers[1].state.precision
 
-    before, after = run(update_confidences=True)
-    assert not jnp.allclose(before, after)  # the confidence state moved
-    before, after = run(update_confidences=False)
+    before, after = run(update_precisions=True)
+    assert not jnp.allclose(before, after)  # the precision state moved
+    before, after = run(update_precisions=False)
     np.testing.assert_allclose(before, after)  # pinned for parity
 
 

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -69,10 +69,10 @@ def test_layer_norm_backward_matches_autodiff():
 def _parity_ff_net(d: int, h: int, w1: jnp.ndarray, w2: jnp.ndarray) -> DeepNetwork:
     """Build a Linear-GELU-Linear DeepNetwork in backprop-parity configuration.
 
-    Bias-free, volatility frozen, high prior confidence on the hidden and input layers,
+    Bias-free, volatility frozen, high prior precision on the hidden and input layers,
     unit precision on the observed output layer.
     """
-    high_confidence = dict(
+    high_precision = dict(
         volatility_parent=False,
         precision=1e4,
         expected_precision=1e4,
@@ -88,9 +88,9 @@ def _parity_ff_net(d: int, h: int, w1: jnp.ndarray, w2: jnp.ndarray) -> DeepNetw
             size=h,
             add_constant_input=False,
             coupling_fn=jax.nn.gelu,
-            **high_confidence,
+            **high_precision,
         )
-        .add_layer(size=d, add_constant_input=False, **high_confidence)
+        .add_layer(size=d, add_constant_input=False, **high_precision)
     )
     elements = list(net.state.layers)
     elements[1] = dataclasses.replace(elements[1], weights_in=w1)

--- a/tests/test_rs_deepnetwork.py
+++ b/tests/test_rs_deepnetwork.py
@@ -518,8 +518,8 @@ def test_batch_update_trajectory_parity(optimizer):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 
 
-def test_batch_update_parity_pinned_confidences():
-    """With pinned confidences the batch step still matches JAX exactly."""
+def test_batch_update_parity_pinned_precisions():
+    """With pinned precisions the batch step still matches JAX exactly."""
     rng = np.random.default_rng(31)
     rs, jx = _matched_pair([2, 3, 3], rng)
     x = rng.normal(size=(6, 3))
@@ -530,9 +530,9 @@ def test_batch_update_parity_pinned_confidences():
             y,
             optimizer="sgd",
             learning_rate=0.05,
-            update_confidences=False,
+            update_precisions=False,
         )
-        jx.batch_update(x, y, optimizer=optax.sgd(0.05), update_confidences=False)
+        jx.batch_update(x, y, optimizer=optax.sgd(0.05), update_precisions=False)
     np.testing.assert_allclose(errors_rs, np.asarray(jx.input_errors), **TRAJECTORY)
     jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -563,7 +563,7 @@ def test_binary_head_at_vocabulary_width():
     )
 
     lr = 1e-3
-    net.batch_update(x, one_hot, optimizer=optax.sgd(lr), update_confidences=False)
+    net.batch_update(x, one_hot, optimizer=optax.sgd(lr), update_precisions=False)
 
     # (b) Input message: matches the sigmoid-cross-entropy gradient at x.
     def bce(x_row, y_row):
@@ -613,7 +613,7 @@ def test_categorical_head_matches_softmax_backprop():
     )
 
     lr = 1e-3
-    net.batch_update(x, one_hot, optimizer=optax.sgd(lr), update_confidences=False)
+    net.batch_update(x, one_hot, optimizer=optax.sgd(lr), update_precisions=False)
 
     # Oracle: batch-mean softmax cross-entropy gradients.
     def loss(w, x_):

--- a/tests/test_transplant.py
+++ b/tests/test_transplant.py
@@ -107,7 +107,7 @@ def test_transplanted_feedforward_learns_like_backprop_with_biases():
     # Transplant, one batch-synchronous step in the parity configuration.
     net = from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY)
     lr = 1e-3
-    net.batch_update(xb, yb, optimizer=optax.sgd(lr), update_confidences=False)
+    net.batch_update(xb, yb, optimizer=optax.sgd(lr), update_precisions=False)
 
     def norm_rel(a, b):
         return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))


### PR DESCRIPTION
Add three boolean controls to `DeepNetwork` to regulate precision propagation and recording.

- `update_input_layer` controls whether the input (leaf) updates its precision after the backward pass.

- `predict_precision` controls whether precision is propagated downward in the forward pass.

- `update_confidences` controls whether precisions are updated and saved after the backward pass.