### PR TITLE
Warn when only part of a network trains, and keep optimiser state

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -378,6 +378,7 @@ The main classes used to create probabilistic networks for binary or continuous 
 
    Network
    DeepNetwork
+   DeadGradientWarning
    add_volatile_state
    add_continuous_state
    add_constant_state

--- a/pyhgf/model/__init__.py
+++ b/pyhgf/model/__init__.py
@@ -14,7 +14,7 @@ from .add_nodes import (
     update_parameters,
 )
 from .builder import LayerConfig, resolve_coupling_fn
-from .deep_network import DeepNetwork
+from .deep_network import DeadGradientWarning, DeepNetwork
 from .error_types import (
     DescentError,
     ObservedMinusPredicted,
@@ -37,6 +37,7 @@ from .transplant import from_embedding, from_feedforward, from_linear, from_line
 
 __all__ = [
     "Network",
+    "DeadGradientWarning",
     "DeepNetwork",
     "LayerConfig",
     "resolve_coupling_fn",

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import warnings
 from typing import Any, Callable, Optional, Union
 
 import equinox as eqx
@@ -29,7 +30,11 @@ from pyhgf.typing.vectorised import (
     Network,
     stack_layers,
 )
+from pyhgf.updates.vectorized.learning import (
+    vectorized_weight_gradient_factors,
+)
 from pyhgf.utils.vectorized_belief_propagation import (
+    _weight_gradients,
     batch_step,
     batched_prediction_pass,
     batched_prediction_states,
@@ -67,6 +72,21 @@ _VOL_STATE_FIELDS: frozenset[str] = frozenset(VOLATILITY_STATE_FIELDS)
 # outweigh the scan setup overhead.
 _SCAN_AUTO_THRESHOLD: int = 5
 _LAYER_OVERRIDE_FIELDS: frozenset[str] = _LAYER_STATE_FIELDS | _LAYER_PARAM_FIELDS
+
+
+class DeadGradientWarning(UserWarning):
+    """Some weight matrices receive essentially no learning signal.
+
+    Raised by :meth:`DeepNetwork.check_gradient_health` when part of the network is
+    training while another part receives (near-)zero gradients — typically the
+    matrices far from the observations. A network in this state silently degrades
+    into a random-feature readout: the live matrices fit against a frozen upper
+    stack, accuracy can look respectable, and nothing else reports the failure.
+
+    The two known causes are Bayesian absorption (each layer's inference consumes
+    most of the error message before passing the residual up) and float32
+    annihilation of the belief-side factor ``(μ − μ̂)·π`` at high precision.
+    """
 
 
 class DeepNetwork:
@@ -656,6 +676,32 @@ class DeepNetwork:
             predict_precision=self.predict_precision,
         )
 
+    def _ensure_optimizer_state(
+        self, optimizer: Optional[optax.GradientTransformation]
+    ) -> None:
+        """Install optimiser state, keeping it when the optimiser is equivalent.
+
+        The state is rebuilt only when there is none yet, or when the new optimiser's
+        state has a *different structure* from the carried one.
+        """
+        if optimizer is None:
+            return
+        # Every caller has already built the network; a state-less network
+        # cannot reach a learning step.
+        assert self.state is not None
+        weights = self.state.weights_tuple()
+        if self.opt_state is None:
+            self.opt_state = optimizer.init(weights)
+        elif self._optimizer is not optimizer:
+            # ``eval_shape`` traces the initialiser without allocating, so the
+            # comparison costs nothing on the common path.
+            candidate = jax.eval_shape(optimizer.init, weights)
+            if jax.tree_util.tree_structure(candidate) != jax.tree_util.tree_structure(
+                self.opt_state
+            ):
+                self.opt_state = optimizer.init(weights)
+        self._optimizer = optimizer
+
     def weight_initialisation(
         self,
         strategy: Optional[str] = None,
@@ -765,6 +811,7 @@ class DeepNetwork:
         weight_update: bool = True,
         time_step: float = 1.0,
         update_precisions: bool = True,
+        check_gradient_health: bool = True,
     ) -> "DeepNetwork":
         r"""Fit network to data.
 
@@ -795,6 +842,18 @@ class DeepNetwork:
             If True (default), the learning phase updates weights each step. If False,
             weights and ``opt_state`` are frozen. Useful for evaluating a fixed model on
             new data while still recording trajectories.
+        check_gradient_health :
+            If True (default), probe the per-matrix gradient magnitudes on the
+            last sample after training and raise :class:`DeadGradientWarning`
+            when part of the network receives no learning signal.
+        update_precisions :
+            If True (default), the carried confidence fields (value-level posterior
+            precision and the volatility level) evolve from sample to sample. If False, they
+            are reset to their pre-fit values after every sample.
+        time_step :
+            Uniform inference time step :math:`\\Delta t` applied at every
+            ``propagation_step``. Replaces the legacy ``net.state.time_step``
+            attribute (``NetworkState`` no longer carries it). Default ``1.0``.
 
         Returns
         -------
@@ -815,10 +874,7 @@ class DeepNetwork:
                     f"Unknown record field(s) {invalid}. Valid: {sorted(valid_fields)}."
                 )
 
-        # Initialise opt_state on first fit, or when the optimiser changes.
-        if self.opt_state is None or self._optimizer is not optimizer:
-            self.opt_state = optimizer.init(self.state.weights_tuple())
-            self._optimizer = optimizer
+        self._ensure_optimizer_state(optimizer)
 
         x = jnp.asarray(x)
         y = jnp.asarray(y)
@@ -840,7 +896,108 @@ class DeepNetwork:
             self.trajectories = None
             self.predictions = step_output
 
+        if check_gradient_health and weight_update:
+            self._warn_if_gradients_dead(x[-1], y[-1], learning_kind)
+
         return self
+
+    def check_gradient_health(
+        self,
+        x: Union[np.ndarray, jnp.ndarray],
+        y: Union[np.ndarray, jnp.ndarray],
+        learning_kind: str = "precision_weighted",
+        relative_floor: float = 1e-9,
+    ) -> dict:
+        """Measure the learning signal each weight matrix actually receives.
+
+        Runs one prediction + update sweep on ``(x, y)`` from the current state
+        (without mutating it), extracts the per-matrix child-side gradient factors,
+        and flags matrices whose signal is zero or negligible relative to the
+        largest. ``fit`` calls this automatically after training and warns.
+
+        Parameters
+        ----------
+        x, y :
+            One sample, shapes ``(n_input_features,)`` and ``(n_output_features,)``.
+        learning_kind :
+            The weight-gradient mode to probe — probe the one being trained with.
+        relative_floor :
+            A matrix counts as dead when its factor magnitude is exactly zero or
+            below this fraction of the largest matrix's magnitude.
+
+        Returns
+        -------
+        dict
+            ``"magnitudes"``: per-element max ``|u|`` (``None`` for the bottom
+            element). ``"dead"``: indices of matrices receiving no usable signal,
+            by either detector — magnitude (exactly zero, or negligible relative
+            to the largest) or quantisation (the child's belief displacement sits
+            within a few float32 ulps of its mean scale, so the belief-side factor
+            is rounding noise; belief-side kinds only). ``"quantised"``: the
+            subset flagged by the quantisation detector.
+        """
+        swept = update_sweep(
+            prediction_sweep(self.state, jnp.asarray(x)), jnp.asarray(y)
+        )
+        factors = _weight_gradients(
+            swept, learning_kind, kernel=vectorized_weight_gradient_factors
+        )
+        magnitudes = [
+            None if f is None else float(np.abs(np.asarray(f[0])).max())
+            for f in factors
+        ]
+        live = max((m for m in magnitudes if m is not None), default=0.0)
+        dead = {
+            i
+            for i, m in enumerate(magnitudes)
+            if m is not None and (m == 0.0 or m < live * relative_floor)
+        }
+
+        # Second detector: a displacement within a few float32 ulps of the mean
+        # scale makes ``(mean - expected_mean)`` pure rounding noise, so
+        # ``pe * precision`` returns quantisation garbage of healthy-looking
+        # magnitude. Measured directly: at precision 1e7 the factors read ~0.3
+        # while carrying no information.
+        quantised: list = []
+        eps32 = float(np.finfo(np.float32).eps)
+        for i in range(1, len(swept.layers)):
+            state = swept.layers[i - 1].state  # the child driving matrix i
+            pe = np.abs(np.asarray(state.value_prediction_error))
+            scale = np.maximum(
+                np.abs(np.asarray(state.mean)),
+                np.abs(np.asarray(state.expected_mean)),
+            )
+            ulps = pe / np.maximum(scale * eps32, 1e-300)
+            if float(np.median(ulps)) < 8.0:
+                quantised.append(i)
+        combined = sorted(dead | set(quantised))
+
+        return {"magnitudes": magnitudes, "dead": combined, "quantised": quantised}
+
+    def _warn_if_gradients_dead(self, x, y, learning_kind: str) -> None:
+        """Run the gradient health check and make a dead upper stack loud."""
+        health = self.check_gradient_health(x, y, learning_kind=learning_kind)
+        healthy = [
+            i
+            for i, m in enumerate(health["magnitudes"])
+            if m is not None and m > 0.0 and i not in health["dead"]
+        ]
+        # Warn only on *partial* death — the head-only-training signature. Uniform
+        # smallness (plain convergence) stays silent.
+        if health["dead"] and healthy:
+            warnings.warn(
+                f"Weight matrices {health['dead']} receive essentially no "
+                f"learning signal under learning_kind={learning_kind!r} while "
+                f"others do: only part of the network is training, and the rest "
+                f"acts as a frozen random-feature map. Likely causes: Bayesian "
+                f"absorption of the error message across layers, or float32 "
+                f"annihilation of (mean - expected_mean) * precision at high "
+                f"precision. Lower the pinned precisions or revisit the "
+                f"precision regime. Silence this check with "
+                f"check_gradient_health=False.",
+                DeadGradientWarning,
+                stacklevel=3,
+            )
 
     def predict(
         self,
@@ -954,10 +1111,7 @@ class DeepNetwork:
         self.state = update_sweep(self.state, y)
 
         if optimizer is not None:
-            # Initialise opt_state on first use, or when the optimiser changes.
-            if self.opt_state is None or self._optimizer is not optimizer:
-                self.opt_state = optimizer.init(self.state.weights_tuple())
-                self._optimizer = optimizer
+            self._ensure_optimizer_state(optimizer)
             self.state, self.opt_state = learn_sweep(
                 self.state, self.opt_state, optimizer, learning_kind
             )
@@ -1088,11 +1242,7 @@ class DeepNetwork:
                 "(batch, n_features)."
             )
 
-        if optimizer is not None and (
-            self.opt_state is None or self._optimizer is not optimizer
-        ):
-            self.opt_state = optimizer.init(self.state.weights_tuple())
-            self._optimizer = optimizer
+        self._ensure_optimizer_state(optimizer)
 
         self.state, self.opt_state, self.input_errors = batch_step(
             self.state,

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -1539,3 +1539,83 @@ def test_fit_update_precisions_false_pins_precisions():
     # The default carries, so the two modes genuinely diverge.
     dynamic = build().fit(x, y, optimizer=optax.sgd(1e-2), learning_kind="standard")
     assert not np.allclose(np.asarray(dynamic.state.layers[1].state.precision), 3.0)
+
+
+# ---------------------------------------------------------------------------
+# The dead-gradient health check
+# ---------------------------------------------------------------------------
+
+
+def _stiff_deep_net(depth=8):
+    """Build a pinned-stiff deep chain that silently kills belief-side gradients."""
+    net = DeepNetwork(coupling_fn=jax.nn.leaky_relu, predict_precision=False).add_layer(
+        size=3, kind="categorical", volatility_parent=False
+    )
+    for _ in range(depth):
+        net.add_layer(
+            size=8,
+            volatility_parent=False,
+            precision=10e6,
+            expected_precision=10e6,
+        )
+    return net.add_layer(
+        size=2,
+        add_constant_input=False,
+        coupling_fn=lambda x: x,
+        volatility_parent=False,
+        precision=1e6,
+        expected_precision=1e6,
+    ).weight_initialisation("he", key=jax.random.key(0))
+
+
+def test_fit_warns_when_only_the_head_trains():
+    """A network training only its head must not fail silently.
+
+    Under the stiff pinned configuration the belief-side gradients are exactly zero
+    above the first few matrices, so ``fit`` must raise ``DeadGradientWarning``.
+    """
+    from pyhgf.model.deep_network import DeadGradientWarning
+
+    rng = np.random.default_rng(1)
+    x = jnp.asarray(rng.normal(size=(24, 2)))
+    y = jnp.asarray(np.eye(3, dtype=np.float32)[rng.integers(0, 3, size=24)])
+
+    with pytest.warns(DeadGradientWarning):
+        _stiff_deep_net().fit(
+            x, y, optimizer=optax.adam(1e-3), learning_kind="precision_weighted"
+        )
+
+
+def test_optimizer_state_survives_a_fresh_optimizer_object():
+    """Constructing the optimiser inside the loop must not reset its moments."""
+    rng = np.random.default_rng(31)
+    x = jnp.asarray(rng.normal(size=(32, _FF_D)).astype(np.float32))
+    y = jnp.asarray(rng.normal(size=(32, _FF_D)).astype(np.float32))
+
+    def run(make_optimizer, steps=5):
+        net, _, _ = _ff_net_with_weights(np.random.default_rng(31))
+        sizes = []
+        for _ in range(steps):
+            before = np.asarray(net.state.layers[2].weights_in).copy()
+            net.batch_update(x, y, optimizer=make_optimizer(), update_precisions=False)
+            sizes.append(
+                float(np.abs(np.asarray(net.state.layers[2].weights_in) - before).max())
+            )
+        return net, sizes
+
+    shared = optax.adam(1e-2)
+    _, reused = run(lambda: shared)
+    net, fresh = run(lambda: optax.adam(1e-2))
+    np.testing.assert_allclose(fresh, reused, rtol=1e-5)
+    # The moments really are accumulating, so the comparison has content.
+    assert fresh[-1] > fresh[0] * (1 + 1e-3), fresh
+
+    # A different optimiser kind rebuilds the state instead of failing.
+    net.batch_update(x, y, optimizer=optax.sgd(1e-2), update_precisions=False)
+
+    # A rate change keeps the moments: the step scales with the new rate.
+    net2, sizes = run(lambda: optax.adam(1e-2), steps=3)
+    before = np.asarray(net2.state.layers[2].weights_in).copy()
+    net2.batch_update(x, y, optimizer=optax.adam(1e-1), update_precisions=False)
+    scaled = float(np.abs(np.asarray(net2.state.layers[2].weights_in) - before).max())
+    assert 8.0 < scaled / sizes[-1] < 12.0, (scaled, sizes[-1])


### PR DESCRIPTION
This PR fixes two silent bugs in the `DeepNetwork` architecture:

- A deep network can train its matrices nearest the observations while the rest receive no learning signal at all, degrading into a random-feature readout whose accuracy still looks respectable. `check_gradient_health` measures the signal each matrix receives and `fit` raises `DeadGradientWarning` on the partial-death signature.

- Optimiser state was rebuilt whenever the optimiser was not the same object, so the ordinary loop

```python
    for batch in batches:
        net.batch_update(x, y, optimizer=optax.adam(1e-3))
```

reset Adam's moments at every step. State is now rebuilt only when there is none or when its structure changes.