### PR TITLE
Control feedforward uncertainty

### DIFF
--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -149,6 +149,7 @@ class DeepNetwork:
         precision_clipping_value: float = 1e-6,
         update_input_layer: bool = False,
         predict_precision: bool = True,
+        feedforward_uncertainty: bool = False,
     ):
         r"""Initialize a VectorizedDeepNetwork.
 
@@ -178,6 +179,15 @@ class DeepNetwork:
         update_input_layer :
             Whether the belief sweeps reach the top (input) layer, which holds the
             predictors. Defaults to ``False``.
+        feedforward_uncertainty :
+            Whether value parents propagate their uncertainty to their children's
+            predicted precision. With ``False`` (the default) they do not: the
+            value-coupling variance is dropped, the marginal and the conditional
+            predicted precision coincide, and the only uncertainty entering a layer is
+            its own volatility parent's, which makes every layer behave as the top
+            layer already does. With ``True`` a volatile layer's marginal predicted
+            precision carries the value-coupling variance, so a parent that is unsure
+            makes its children less precise.
         """
         self.coupling_fn = coupling_fn
         self.volatility_updates = volatility_updates
@@ -185,6 +195,7 @@ class DeepNetwork:
         self.precision_clipping_value = float(precision_clipping_value)
         self.update_input_layer = bool(update_input_layer)
         self.predict_precision = bool(predict_precision)
+        self.feedforward_uncertainty = bool(feedforward_uncertainty)
         self.layer_sizes: list[int] = []
         self.layer_kinds: list[str] = []
         # Per-layer overrides for fields of ``LayerState`` and ``LayerParams``.
@@ -674,6 +685,7 @@ class DeepNetwork:
             precision_clipping_value=self.precision_clipping_value,
             update_input_layer=self.update_input_layer,
             predict_precision=self.predict_precision,
+            feedforward_uncertainty=self.feedforward_uncertainty,
         )
 
     def _ensure_optimizer_state(

--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -331,6 +331,9 @@ class Network(eqx.Module):
     predict_precision :
         Whether the prediction sweep advances the precisions — see
         :func:`pyhgf.updates.vectorized.volatile.prediction.vectorized_layer_prediction`.
+    feedforward_uncertainty :
+        Whether value parents propagate their uncertainty to their children's
+        predicted precision — see :class:`pyhgf.model.DeepNetwork`.
     """
 
     layers: tuple
@@ -339,6 +342,7 @@ class Network(eqx.Module):
     precision_clipping_value: float = field(static=True, default=1e-6)
     update_input_layer: bool = field(static=True, default=False)
     predict_precision: bool = field(static=True, default=True)
+    feedforward_uncertainty: bool = field(static=True, default=False)
 
     @property
     def n_layers(self) -> int:

--- a/pyhgf/updates/vectorized/volatile/prediction.py
+++ b/pyhgf/updates/vectorized/volatile/prediction.py
@@ -84,6 +84,7 @@ def vectorized_layer_prediction(
     has_volatility_parent: bool = True,
     is_input_layer: bool = False,
     predict_precision: bool = True,
+    feedforward_uncertainty: bool = False,
 ) -> LayerState:
     r"""Predict expected mean/precision for all nodes in a volatile-node layer.
 
@@ -141,6 +142,12 @@ def vectorized_layer_prediction(
         If False, the value level has no volatility source at all, so it does not
         undergo a Gaussian random walk: the diffusion term is dropped and the
         conditional predicted precision equals the prior precision.
+    feedforward_uncertainty :
+        Whether the value parents propagate their uncertainty to this layer. With
+        ``False`` (the default) they do not: the value-coupling variance is dropped,
+        so the marginal and the conditional predicted precision coincide and the only
+        uncertainty entering the layer is its own volatility parent's. With ``True``
+        the parent's uncertainty bleeds through as the law of total variance requires.
     predict_precision :
         Whether the prediction step advances the precisions at all. With ``False``
         both predicted precisions are held at the layer's prior precision, the
@@ -211,18 +218,29 @@ def vectorized_layer_prediction(
         #     Σ_j (t · W[i, j] · g'(μ̂_j))² / π̃_j,
         # using the parent's marginal predicted precision π̃_j (= `expected_precision`).
         # The constant-bias parent (if any) has infinite precision and contributes zero.
-        parent_precision = parent_state.expected_precision
-        g_prime = vmap(grad(coupling_fn))(parent_state.expected_mean)
-        if parent_has_constant:
-            # The constant node never varies: zero derivative, infinite precision.
-            parent_precision = jnp.concatenate([parent_precision, jnp.array([jnp.inf])])
-            g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
-        # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ (g'² / π): the
-        # weight-dependent factor is a constant matrix, so the per-node sum is a
-        # matrix product with a per-node vector.
-        # The variance carries no time step (deviation from the Network class).
-        per_parent_variance = g_prime**2 / parent_precision
-        value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
+        if not feedforward_uncertainty:
+            # No uncertainty is propagated by the value parents: the child's predicted
+            # precision comes from its own prior and its own volatility parent alone,
+            # which is what :func:`vectorized_root_prediction` already does for the top
+            # layer. The parent's derivative is not needed, so the autodiff call goes
+            # with it.
+            value_coupling_variance = jnp.zeros_like(child_state.precision)
+        else:
+            parent_precision = parent_state.expected_precision
+            g_prime = vmap(grad(coupling_fn))(parent_state.expected_mean)
+            if parent_has_constant:
+                # The constant node never varies: zero derivative, infinite precision.
+                parent_precision = jnp.concatenate([
+                    parent_precision,
+                    jnp.array([jnp.inf]),
+                ])
+                g_prime = jnp.concatenate([g_prime, jnp.zeros(1)])
+            # Σ_j (t · W[i, j] · g'_j)² / π_j, computed as (W²) @ (g'² / π): the
+            # weight-dependent factor is a constant matrix, so the per-node sum is a
+            # matrix product with a per-node vector.
+            # The variance carries no time step (deviation from the Network class).
+            per_parent_variance = g_prime**2 / parent_precision
+            value_coupling_variance = jnp.matmul(weights**2, per_parent_variance)
 
         # Conditional predicted precision π̂_a — the precision of x_a given a specific
         # value of x_b (own AR-plus-volatility variance only, no parent-uncertainty

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -102,6 +102,7 @@ def _predict_layer_from_parent(
     time_step: float,
     precision_clipping_value: float,
     predict_precision: bool = True,
+    feedforward_uncertainty: bool = False,
 ):
     """Predict a single ``Layer`` child from a parent view."""
     if child.kind == "binary":
@@ -133,6 +134,7 @@ def _predict_layer_from_parent(
             has_volatility_parent=child.has_volatility_parent,
             is_input_layer=child.is_input_layer,
             predict_precision=predict_precision,
+            feedforward_uncertainty=feedforward_uncertainty,
         )
     return dataclasses.replace(child, state=new_state)
 
@@ -146,6 +148,7 @@ def _predict_stack_from_parent(
     *,
     time_step: float,
     predict_precision: bool = True,
+    feedforward_uncertainty: bool = False,
 ):
     """Top-down sweep over a ``LayerStack``.
 
@@ -169,6 +172,7 @@ def _predict_stack_from_parent(
         has_volatility_parent=stack.has_volatility_parent,
         is_input_layer=False,
         predict_precision=predict_precision,
+        feedforward_uncertainty=feedforward_uncertainty,
     )
 
     # xs: per-iteration data for predicting slices N-2 ... 0 from the slice above.
@@ -194,6 +198,7 @@ def _predict_stack_from_parent(
             has_volatility_parent=stack.has_volatility_parent,
             is_input_layer=False,
             predict_precision=predict_precision,
+            feedforward_uncertainty=feedforward_uncertainty,
         )
         return new_child_state, new_child_state
 
@@ -221,6 +226,7 @@ def _topdown_predict(
     time_step: float,
     precision_clipping_value: float,
     predict_precision: bool = True,
+    feedforward_uncertainty: bool = False,
 ):
     """Predict ``child_elem`` from ``parent_elem``.
 
@@ -239,6 +245,7 @@ def _topdown_predict(
             parent_has_const,
             time_step=time_step,
             predict_precision=predict_precision,
+            feedforward_uncertainty=feedforward_uncertainty,
         )
     return _predict_layer_from_parent(
         child_elem,
@@ -249,6 +256,7 @@ def _topdown_predict(
         time_step=time_step,
         precision_clipping_value=precision_clipping_value,
         predict_precision=predict_precision,
+        feedforward_uncertainty=feedforward_uncertainty,
     )
 
 
@@ -794,6 +802,7 @@ def _prediction_sweep(
             time_step=time_step,
             precision_clipping_value=network.precision_clipping_value,
             predict_precision=network.predict_precision,
+            feedforward_uncertainty=network.feedforward_uncertainty,
         )
 
     return dataclasses.replace(network, layers=tuple(elements))

--- a/src/model/deep_network.rs
+++ b/src/model/deep_network.rs
@@ -47,6 +47,7 @@ pub struct DeepNetwork {
     max_posterior_precision: Float,
     precision_clipping_value: Float,
     predict_precision: bool,
+    feedforward_uncertainty: bool,
     /// Network-level default coupling function name (validated at
     /// construction).
     default_coupling: String,
@@ -76,6 +77,7 @@ impl DeepNetwork {
             self.max_posterior_precision,
             self.precision_clipping_value,
             self.predict_precision,
+            self.feedforward_uncertainty,
         );
         self.net = Some(net);
         self.opt_state = None;
@@ -221,6 +223,7 @@ impl DeepNetwork {
         precision_clipping_value = 1e-6,
         coupling_fn = "linear",
         predict_precision = true,
+        feedforward_uncertainty = false,
     ))]
     fn py_new(
         volatility_updates: &str,
@@ -228,6 +231,7 @@ impl DeepNetwork {
         precision_clipping_value: Float,
         coupling_fn: &str,
         predict_precision: bool,
+        feedforward_uncertainty: bool,
     ) -> PyResult<Self> {
         let volatility_updates =
             VolatilityUpdate::parse(volatility_updates).map_err(PyValueError::new_err)?;
@@ -251,6 +255,7 @@ impl DeepNetwork {
             max_posterior_precision,
             precision_clipping_value,
             predict_precision,
+            feedforward_uncertainty,
             default_coupling: coupling_fn.to_string(),
         })
     }

--- a/src/updates/vectorised/volatile/prediction.rs
+++ b/src/updates/vectorised/volatile/prediction.rs
@@ -29,6 +29,7 @@ pub fn layer_prediction(
     has_volatility_parent: bool,
     is_input_layer: bool,
     predict_precision: bool,
+    feedforward_uncertainty: bool,
 ) {
     let n = child.mean.len();
     let n_parent = parent.expected_mean.len();
@@ -106,14 +107,19 @@ pub fn layer_prediction(
     };
 
     // Laplace value-coupling variance vcv[i] = Σ_j W[i,j]²·ppv[j] (no W² matrix).
+    // Without `feedforward_uncertainty` the value parents do not propagate their
+    // uncertainty, so the term is zero and the marginal predicted precision collapses
+    // onto the conditional one: every layer then behaves as the top layer already does.
     let mut value_coupling_variance = Array1::<Float>::zeros(n);
-    for i in 0..n {
-        let mut s = 0.0;
-        for j in 0..p {
-            let w = weights[[i, j]];
-            s += w * w * ppv[j];
+    if feedforward_uncertainty {
+        for i in 0..n {
+            let mut s = 0.0;
+            for j in 0..p {
+                let w = weights[[i, j]];
+                s += w * w * ppv[j];
+            }
+            value_coupling_variance[i] = s;
         }
-        value_coupling_variance[i] = s;
     }
 
     // Conditional (π̂) and marginal (π̃) predicted precisions, written in place.
@@ -182,6 +188,7 @@ mod tests {
             true,
             false,
             true,
+            true,
         );
         // rows: [1,0]·[1,2]=1, [0,1]·[1,2]=2, [1,1]·[1,2]=3
         assert!((child.expected_mean[0] - 1.0).abs() < 1e-12);
@@ -210,6 +217,7 @@ mod tests {
             true,
             false,
             true,
+            true,
         );
         // 3*2 + 5*1 = 11
         assert!((child.expected_mean[0] - 11.0).abs() < 1e-12);
@@ -236,10 +244,63 @@ mod tests {
             true,
             true, // is_input_layer
             true,
+            true,
         );
         assert_eq!(child.expected_precision, prior_precision);
         assert_eq!(child.conditional_expected_precision, prior_precision);
         assert!(child.effective_precision.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn test_feedforward_uncertainty_controls_the_value_coupling_variance() {
+        // With the flag off (the default) the value parents propagate nothing: the
+        // marginal predicted precision collapses onto the conditional one, which is
+        // exactly what a layer with no value parent already computes. The conditional
+        // is unaffected either way, since it never carried the parent's contribution.
+        let mut parent = LayerState::create(2, true);
+        // A parent that is genuinely uncertain, so the dropped term is non-zero.
+        parent.expected_precision.assign(&Array1::from(vec![0.5, 2.0]));
+        parent.expected_mean.assign(&Array1::from(vec![0.3, -0.7]));
+        let child_params = LayerParams::create(3);
+        let weights =
+            Matrix::from_shape_vec((3, 2), vec![0.7, -0.4, 0.2, 0.9, -0.5, 0.3]).unwrap();
+
+        let run = |feedforward_uncertainty: bool| {
+            let mut child = LayerState::create(3, true);
+            layer_prediction(
+                &mut child,
+                &child_params,
+                &parent,
+                &weights,
+                linear(),
+                1.0,
+                false,
+                true,  // has_volatility_parent
+                false, // is_input_layer
+                true,  // predict_precision
+                feedforward_uncertainty,
+            );
+            child
+        };
+
+        let off = run(false);
+        let on = run(true);
+
+        // On: the parent's uncertainty bleeds through, so the two differ.
+        assert!(
+            on.expected_precision
+                .iter()
+                .zip(on.conditional_expected_precision.iter())
+                .any(|(e, c)| (e - c).abs() > 1e-12),
+            "the value-coupling variance should separate the two precisions"
+        );
+        // Off: they coincide.
+        assert_eq!(off.expected_precision, off.conditional_expected_precision);
+        // The conditional is the same under both settings.
+        assert_eq!(
+            off.conditional_expected_precision,
+            on.conditional_expected_precision
+        );
     }
 
     #[test]
@@ -264,6 +325,7 @@ mod tests {
             true,  // has_volatility_parent
             false, // is_input_layer
             false, // predict_precision
+            true, // feedforward_uncertainty
         );
 
         assert_eq!(child.expected_precision, prior_precision);

--- a/src/vectorised/batched.rs
+++ b/src/vectorised/batched.rs
@@ -186,6 +186,7 @@ fn batched_volatile_prediction(
     weights: &Matrix,
     parent_layer: &Layer,
     time_step: Float,
+    feedforward_uncertainty: bool,
 ) {
     let params = &child_layer.params;
     let (n, n_samples) = child.mean.dim();
@@ -244,9 +245,17 @@ fn batched_volatile_prediction(
     // Mean prediction: one gemm over the whole batch.
     child.expected_mean = weights.dot(&coupled);
 
-    // Laplace value-coupling variance: W² @ ppv, one gemm.
-    let w2 = weights.mapv(|w| w * w);
-    let value_coupling_variance = w2.dot(&ppv);
+    // Laplace value-coupling variance: W² @ ppv, one gemm. Without
+    // `feedforward_uncertainty` the value parents propagate nothing, so the term is
+    // zero and the marginal predicted precision collapses onto the conditional one.
+    let value_coupling_variance = if feedforward_uncertainty {
+        let w2 = weights.mapv(|w| w * w);
+        w2.dot(&ppv)
+    } else {
+        // Shaped like the product, (n, n_samples), not like ppv, which is
+        // (n_parent + bias, n_samples).
+        Matrix::zeros((n, n_samples))
+    };
 
     // Conditional (π̂), marginal (π̃), and effective (γ) predicted precisions,
     // fused into a single pass over the state: π̂ = 1/(1/π + Ω),
@@ -622,6 +631,7 @@ pub fn batched_prediction_sweep(
                 weights,
                 parent_layer,
                 time_step,
+                net.feedforward_uncertainty,
             ),
             LayerKind::Binary => batched_binary_prediction(
                 child,

--- a/src/vectorised/layer.rs
+++ b/src/vectorised/layer.rs
@@ -335,6 +335,12 @@ pub struct DeepNet {
     /// effective precision is zero and its volatility level is left untouched,
     /// so prediction produces only the expected means.
     pub predict_precision: bool,
+    /// Whether value parents propagate their uncertainty to their children's
+    /// predicted precision. With `false` (the default) they do not: the
+    /// value-coupling variance is dropped, so the marginal and the conditional
+    /// predicted precision coincide and the only uncertainty entering a layer is its
+    /// own volatility parent's. With `true` that term is carried.
+    pub feedforward_uncertainty: bool,
 }
 
 impl DeepNet {
@@ -420,6 +426,7 @@ impl DeepNet {
             max_posterior_precision: 1e10,
             precision_clipping_value: 1e-6,
             predict_precision: true,
+            feedforward_uncertainty: false,
         })
     }
 
@@ -430,11 +437,13 @@ impl DeepNet {
         max_posterior_precision: Float,
         precision_clipping_value: Float,
         predict_precision: bool,
+        feedforward_uncertainty: bool,
     ) -> Self {
         self.volatility_updates = volatility_updates;
         self.max_posterior_precision = max_posterior_precision;
         self.precision_clipping_value = precision_clipping_value;
         self.predict_precision = predict_precision;
+        self.feedforward_uncertainty = feedforward_uncertainty;
         self
     }
 

--- a/src/vectorised/network.rs
+++ b/src/vectorised/network.rs
@@ -31,6 +31,7 @@ fn predict_child(
     time_step: Float,
     pcv: Float,
     predict_precision: bool,
+    feedforward_uncertainty: bool,
 ) {
     match child.kind {
         LayerKind::Volatile => volatile::prediction::layer_prediction(
@@ -44,6 +45,7 @@ fn predict_child(
             child.has_volatility_parent,
             child.is_input_layer,
             predict_precision,
+            feedforward_uncertainty,
         ),
         LayerKind::Binary => binary::prediction::binary_prediction(
             &mut child.state,
@@ -139,12 +141,21 @@ impl DeepNet {
         self.set_top_predictors(x);
         let pcv = self.precision_clipping_value;
         let predict_precision = self.predict_precision;
+        let feedforward_uncertainty = self.feedforward_uncertainty;
         for i in (1..n).rev() {
             let (lower, upper) = self.layers.split_at_mut(i);
             let child = &mut lower[i - 1];
             let parent = &upper[0];
             let weights = parent.weights_in.as_ref().expect("parent has no weights");
-            predict_child(child, parent, weights, time_step, pcv, predict_precision);
+            predict_child(
+                child,
+                parent,
+                weights,
+                time_step,
+                pcv,
+                predict_precision,
+                feedforward_uncertainty,
+            );
         }
     }
 

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -394,7 +394,12 @@ def test_three_backends_binary_volatile():
 
         # --- DeepNetwork (JAX vectorized) ---
         dn = (
-            DeepNetwork(volatility_updates=volatility_updates)
+            DeepNetwork(
+                volatility_updates=volatility_updates,
+                # The nodalised backends always propagate value-parent
+                # uncertainty, so the vectorised one has to be asked to.
+                feedforward_uncertainty=True,
+            )
             .add_layer(size=n_targets, kind="binary")
             .add_layer(size=n_targets, add_constant_input=False, fully_connected=False)
             .add_layer(size=n_hidden)
@@ -1254,14 +1259,17 @@ def test_input_layer_precision_equilibrates_instead_of_running_away():
     volatility prediction error can never be positive, so a layer that did update it
     would drive its own diffusion to zero and then accumulate evidence forever. Held
     at the tonic value, the diffusion bounds the precision.
+
+    At the default, where value parents propagate nothing, it settles near 7.11; with
+    ``feedforward_uncertainty=True`` it settles lower, near 4.45, and sooner.
     """
     x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
     net = _three_layer(True)
 
     seen = []
-    for step in range(400):
+    for step in range(2000):
         net.prediction(x).update(y)
-        if step in (0, 199, 399):
+        if step in (0, 999, 1999):
             seen.append(
                 float(np.mean(np.asarray(net.state.layers[-1].state.precision)))
             )
@@ -1361,6 +1369,71 @@ def test_input_layer_precision_tracks_the_routed_evidence_not_the_residual():
 
     stronger = settle(jnp.asarray(np.asarray(x) @ w.T), 2.0 * w)
     assert stronger > explained
+
+
+# ---------------------------------------------------------------------------
+# ``feedforward_uncertainty``: withholding a parent's uncertainty
+# ---------------------------------------------------------------------------
+
+
+def _feedforward_net(feedforward_uncertainty):
+    """Build a 2 -> 2 -> 2 chain, optionally propagating parent uncertainty."""
+    net = DeepNetwork(
+        coupling_fn=jax.nn.leaky_relu,
+        feedforward_uncertainty=feedforward_uncertainty,
+    )
+    for _ in range(3):
+        net.add_layer(size=2, add_constant_input=False, volatility_parent=True)
+    return net
+
+
+def test_feedforward_uncertainty_false_propagates_no_parent_uncertainty():
+    """The default: value parents contribute nothing to a child's precision."""
+    x = jnp.array([0.7, -0.4])
+    local = _feedforward_net(False).prediction(x)
+
+    for layer in local.state.layers:
+        state = layer.state
+        np.testing.assert_allclose(
+            state.expected_precision,
+            state.conditional_expected_precision,
+            rtol=1e-6,
+        )
+
+
+def test_feedforward_uncertainty_true_propagates_parent_uncertainty():
+    """With the flag on, the value-coupling variance separates the two precisions."""
+    x = jnp.array([0.7, -0.4])
+    coupled = _feedforward_net(True).prediction(x)
+
+    # The top layer has no value parent, so only the layers below it can differ.
+    separated = [
+        not np.allclose(
+            np.asarray(layer.state.expected_precision),
+            np.asarray(layer.state.conditional_expected_precision),
+        )
+        for layer in coupled.state.layers[:-1]
+    ]
+    assert any(separated), "the value-coupling variance should separate the two"
+
+
+def test_feedforward_uncertainty_leaves_the_conditional_precision_alone():
+    """The flag governs only the parent's contribution, not the layer's own."""
+    x = jnp.array([0.7, -0.4])
+    off = _feedforward_net(False).prediction(x)
+    on = _feedforward_net(True).prediction(x)
+
+    for a, b in zip(off.state.layers, on.state.layers):
+        np.testing.assert_allclose(
+            a.state.conditional_expected_precision,
+            b.state.conditional_expected_precision,
+            rtol=1e-6,
+        )
+
+
+def test_feedforward_uncertainty_defaults_to_off():
+    """Value parents do not propagate their uncertainty unless asked to."""
+    assert DeepNetwork().feedforward_uncertainty is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a `feedforward_uncertainty` flag to `DeepNetwork`, governing whether a value parent propagates its uncertainty to its children's predicted precision. Both the JAX and the Rust vectorised paths carry it.

- With `True` a volatile layer's marginal predicted precision carries the value-coupling variance, as the law of total variance requires, so a parent that is unsure makes its children less precise. This is the behaviour the backend had until now.

- With `False` — the new default — the value-coupling variance is dropped: the marginal and the conditional predicted precision coincide, and the only uncertainty entering a layer is its own volatility parent's. Every layer then behaves as `vectorized_root_prediction` already makes the top layer behave. The parent's derivative is not needed on that branch, so the `vmap(grad(coupling_fn))` call goes with it.

The flag is a static field on `Network`, so it is fixed when the state is built and travels unchanged through the fused and batched sweeps.
