### PR TITLE
Support the merge queue in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ name: Build and Deploy
 on:
   release:
     types: [published]
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -54,19 +52,9 @@ jobs:
           # notebook execution cache (nb_execution_mode = "cache") instead.
           uv run sphinx-build -j 1 -T -b html docs/source docs/build/html
 
-      # 5. Deploy the documentation for the 'release' event
+      # 5. Deploy the documentation
       - name: Deploy Stable 🚀
-        if: github.event_name == 'release'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/build/html
           branch: gh-pages
-
-      # 6. Deploy the documentation for pull requests (Dev version)
-      - name: Deploy Dev 🚀
-        if: github.event_name == 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: docs/build/html
-          branch: gh-pages
-          target-folder: dev

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "*"
+  merge_group:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-rs.yml
+++ b/.github/workflows/test-rs.yml
@@ -5,6 +5,7 @@ on:
       types: [published]
     pull_request:
       types: [opened, synchronize, reopened]
+    merge_group:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     # This will run the action for pull requests from any branch
     branches:
       - '*'
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
Prepares the workflows for a merge queue.

- `merge_group` is added to the triggers of `ci`, `linting`, `test-rs` and `test`. A required check that does not run on `merge_group` never reports inside the queue, so the queue would stall waiting for it.

- `docs` no longer builds on pull requests, and the `Deploy Dev` step that published `docs/build/html` to `gh-pages/dev` is removed with it. That step rewrote the published dev documentation from whichever unmerged branch ran last. Documentation now deploys on release only, and the remaining `Deploy Stable` step loses its `if:` guard because `release` is the only event left.
