### PR TITLE
Add continuous layers (DAG) to the vectorised backend

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -354,6 +354,25 @@ Categorical layers
     vectorized_categorical_prediction
     vectorized_categorical_prediction_error
 
+Continuous layers
+-----------------
+
+.. currentmodule:: pyhgf.updates.vectorized.continuous
+
+.. autosummary::
+   :toctree: generated/pyhgf.updates.vectorized.continuous
+
+    ValueChild
+    VolatilityChild
+    vectorized_continuous_prediction
+    vectorized_continuous_prediction_error
+    vectorized_continuous_value_prediction_error
+    vectorized_continuous_volatility_prediction_error
+    vectorized_continuous_posterior_update
+    vectorized_continuous_posterior_update_standard
+    vectorized_continuous_posterior_update_ehgf
+    vectorized_continuous_posterior_update_unbounded
+
 Vectorized learning
 -------------------
 
@@ -598,6 +617,7 @@ Scan-based belief propagation used internally by :class:`pyhgf.model.DeepNetwork
    propagation_step
    prediction_pass
    run_scan
+   run_continuous_scan
    prediction_sweep
    update_sweep
    learn_sweep

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -43,6 +43,7 @@ from pyhgf.utils.vectorized_belief_propagation import (
     learn_sweep,
     prediction_pass,
     prediction_sweep,
+    run_continuous_scan,
     run_scan,
     update_sweep,
 )
@@ -66,6 +67,12 @@ _LAYER_PARAM_FIELDS: frozenset[str] = frozenset(LayerParams.__dataclass_fields__
 # volatility parent — a state override for one of these on such a layer is
 # dropped rather than re-allocating the array.
 _VOL_STATE_FIELDS: frozenset[str] = frozenset(VOLATILITY_STATE_FIELDS)
+# ``LayerParams`` fields carried by continuous layers only.
+_CONTINUOUS_PARAM_FIELDS: frozenset[str] = frozenset({
+    "tonic_volatility",
+    "tonic_drift",
+    "autoconnection_strength",
+})
 
 # Minimum identical-layer count for ``add_layer_stack`` to auto-collapse the
 # block into a ``LayerStack`` (i.e. switch the propagation kernels to
@@ -206,6 +213,16 @@ class DeepNetwork:
         self.fully_connected: list[bool] = []
         self.coupling_fns: list[Callable] = []  # per-layer coupling functions
         self.volatility_parents: list[bool] = []
+        # Continuous-layer topology: for each layer, the index of the layer it
+        # is the value / volatility parent of (``None`` when it has no such
+        # child), plus the base strengths and connectivity of its W and κ
+        # matrices (see ``_fan_in_matrix``). Other kinds carry the resolved
+        # defaults here and never read them.
+        self.value_children: list[Optional[int]] = []
+        self.volatility_children: list[Optional[int]] = []
+        self.value_couplings: list[float] = []
+        self.volatility_couplings: list[float] = []
+        self.volatility_fully_connected: list[bool] = []
         # Indices of consecutive layers to collapse into a ``LayerStack`` at
         # ``_init_state`` time. Each entry is a ``(start, end_exclusive)`` half-
         # open interval over ``self.layer_sizes``, populated automatically by
@@ -220,6 +237,14 @@ class DeepNetwork:
         # Per-sample input-layer errors from the last batch_update call,
         # shape (batch, n_input_features).
         self.input_errors: Optional[jnp.ndarray] = None
+
+    @property
+    def _is_continuous(self) -> bool:
+        """Whether this is a continuous network.
+
+        Kinds cannot mix within a network, so layer 0 decides for all of them.
+        """
+        return bool(self.layer_kinds) and self.layer_kinds[0] == "continuous"
 
     @classmethod
     def from_configs(
@@ -306,8 +331,10 @@ class DeepNetwork:
             if layer_coupling_fn is None:
                 layer_coupling_fn = net_coupling_fn
 
-            # Prepare per-layer parameter overrides
-            overrides = {}
+            # Prepare per-layer parameter overrides. Annotated as ``Any`` so
+            # unpacking below type-checks against ``add_layer``'s typed
+            # keyword parameters, not just the float-valued ``**kwargs``.
+            overrides: dict[str, Any] = {}
             if config.tonic_volatility_vol is not None:
                 overrides["tonic_volatility_vol"] = config.tonic_volatility_vol
 
@@ -408,13 +435,18 @@ class DeepNetwork:
         self,
         size: int,
         kind: str = "volatile",
-        add_constant_input: bool = True,
+        add_constant_input: Optional[bool] = None,
         fully_connected: bool = True,
         coupling_fn: Optional[Callable] = None,
         volatility_parent: bool = True,
+        value_children: Optional[int] = None,
+        volatility_children: Optional[int] = None,
+        value_coupling: Optional[float] = None,
+        volatility_coupling: Optional[float] = None,
+        volatility_fully_connected: Optional[bool] = None,
         **kwargs,
     ) -> "DeepNetwork":
-        """Add a layer of nodes.
+        r"""Add a layer of nodes.
 
         Parameters
         ----------
@@ -433,9 +465,16 @@ class DeepNetwork:
             expected mean is the softmax across the layer's nodes, and the observation
             clamped during :meth:`fit` must be one-hot. Only valid as the output
             (bottom) layer. See ``docs/source/notebooks/1.1-Binary_HGF.ipynb`` for the
-            binary case.
+            binary case. ``"continuous"`` uses regular continuous state nodes with the
+            standard HGF drift semantics; continuous layers cannot mix with the other
+            kinds, are filtered with :meth:`input_data` rather than :meth:`fit`, and
+            connect through explicit value / volatility parent edges (see
+            *value_children* / *volatility_children*).
         add_constant_input :
-            If `True`, add a bias term to the layer's predictions.
+            If `True`, add a bias term to the layer's predictions. ``None`` (default)
+            resolves to `True` for volatile/binary/categorical layers and `False` for
+            continuous layers, whose per-node ``tonic_drift`` already plays the bias
+            role (passing `True` with a continuous layer raises).
         fully_connected :
             If `True` (default), each node in this layer connects to every node in the
             child layer (dense weight matrix).  If False, nodes connect one-to-one with
@@ -449,7 +488,44 @@ class DeepNetwork:
             mean_vol and precision_vol are predicted and updated each step. If False,
             the value level has no volatility source and does not undergo a Gaussian
             random walk (its conditional predicted precision equals the prior
-            precision).
+            precision). Volatile layers only — continuous layers have no internal
+            volatility level and ignore this argument.
+        value_children :
+            Continuous layers only. Index of the existing layer this layer is the
+            *value parent* of. When neither *value_children* nor
+            *volatility_children* is given, the chain default applies: the new layer
+            becomes the value parent of the previously added layer. Naming a parent
+            explicitly replaces the chain default entirely, so a layer given only
+            *volatility_children* is not a value parent of anything.
+        volatility_children :
+            Continuous layers only. Index of the existing layer this layer is the
+            *volatility parent* of. The κ matrix connecting the two is fixed at
+            construction (see *volatility_coupling*) and never learned.
+        value_coupling :
+            Continuous layers only — base value coupling strength (defaults to
+            ``1.0``). Dense ``weights_in`` entries are ``value_coupling /
+            n_parents``, so the drift a child receives is ``value_coupling``
+            times the *average* of :math:`g(\hat{\mu})` over the parent layer,
+            invariant to the parent layer's width; one-to-one edges keep
+            ``value_coupling`` on the diagonal (fan-in 1). Volatile and binary
+            layers have no fixed value coupling — their weights are learned, or
+            set via :meth:`weight_initialisation`.
+        volatility_coupling :
+            Continuous layers only — base volatility coupling strength
+            :math:`\kappa_0` (defaults to ``1.0``). Dense κ entries are
+            :math:`\kappa_0 / n_{\mathrm{parents}}` — the fan-in normalisation
+            makes the phasic volatility a child receives :math:`\kappa_0` times
+            the *average* of the parent layer's means, invariant to the parent
+            layer's width (and its MGF correction the variance of that average).
+            One-to-one κ has fan-in 1 and keeps :math:`\kappa_0` on the diagonal.
+            Mirrors the drift-averaging the volatile backend applies on value
+            edges.
+        volatility_fully_connected :
+            Continuous layers only. If True (the default), κ is dense: every node
+            of this layer modulates the volatility of every node of the child
+            layer. If False, κ is diagonal (one-to-one), which requires equal
+            sizes and is the only connectivity supported by the ``"unbounded"``
+            volatility update.
         **kwargs :
             Per-layer overrides for any field of :class:`pyhgf.typing.LayerState`
             (e.g. ``mean``, ``precision``, ``expected_mean``, ``expected_precision``,
@@ -477,14 +553,70 @@ class DeepNetwork:
             "volatile-state": "volatile",
             "binary-state": "binary",
             "categorical-state": "categorical",
+            "continuous-state": "continuous",
         }
         kind = _kind_aliases.get(kind, kind)
 
-        valid_kinds = {"volatile", "binary", "categorical"}
+        valid_kinds = {"volatile", "binary", "categorical", "continuous"}
         if kind not in valid_kinds:
             raise ValueError(
                 f"Invalid layer kind '{kind}'. Choose from {sorted(valid_kinds)}."
             )
+
+        # Continuous layers form their own network type: the sweeps, the edge
+        # semantics (drift vs. direct prediction), and the entry point
+        # (``input_data`` vs. ``fit``) all differ, so mixing is rejected.
+        if self.layer_kinds and self._is_continuous != (kind == "continuous"):
+            raise ValueError(
+                "Continuous layers cannot mix with volatile/binary/"
+                "categorical layers in one network."
+            )
+
+        # The continuous-only arguments all default to ``None`` so an explicit
+        # value on another kind is an error rather than a silent no-op.
+        if kind != "continuous":
+            misplaced = [
+                name
+                for name, value in (
+                    ("value_children", value_children),
+                    ("volatility_children", volatility_children),
+                    ("value_coupling", value_coupling),
+                    ("volatility_coupling", volatility_coupling),
+                    ("volatility_fully_connected", volatility_fully_connected),
+                )
+                if value is not None
+            ]
+            if misplaced:
+                raise ValueError(
+                    f"{', '.join(misplaced)} are only valid for continuous layers."
+                )
+
+        if kind == "continuous":
+            if add_constant_input:
+                raise ValueError(
+                    "Continuous layers cannot use add_constant_input=True: the "
+                    "per-node tonic_drift already provides a constant offset."
+                )
+            add_constant_input = False
+        elif add_constant_input is None:
+            add_constant_input = True
+
+        value_coupling = 1.0 if value_coupling is None else value_coupling
+        volatility_coupling = (
+            1.0 if volatility_coupling is None else volatility_coupling
+        )
+        volatility_fully_connected = (
+            True if volatility_fully_connected is None else volatility_fully_connected
+        )
+
+        value_child, volatility_child = self._resolve_continuous_children(
+            kind=kind,
+            size=size,
+            value_children=value_children,
+            volatility_children=volatility_children,
+            volatility_fully_connected=volatility_fully_connected,
+        )
+
         if kind == "categorical" and self.layer_sizes:
             # A softmax couples every node of the layer into one choice; that
             # is only meaningful for the observed (bottom) layer, where the
@@ -500,6 +632,18 @@ class DeepNetwork:
                 f"Unknown layer override(s): {invalid_keys}. "
                 f"Valid fields are {sorted(_LAYER_OVERRIDE_FIELDS)}."
             )
+        # Parameter fields are kind-specific: reject an override the layer's
+        # kind would silently ignore.
+        wrong_params = [
+            k
+            for k in kwargs
+            if k in _LAYER_PARAM_FIELDS
+            and (k in _CONTINUOUS_PARAM_FIELDS) != (kind == "continuous")
+        ]
+        if wrong_params:
+            raise ValueError(
+                f"Parameter override(s) {wrong_params} do not apply to {kind!r} layers."
+            )
 
         if not fully_connected:
             if add_constant_input:
@@ -507,10 +651,18 @@ class DeepNetwork:
                     "One-to-one layers (fully_connected=False) cannot use "
                     "add_constant_input=True."
                 )
-            if self.layer_sizes and self.layer_sizes[-1] != size:
+            # The value edge connects this layer to its value child — the
+            # previous layer for the chain kinds, the resolved child for
+            # continuous layers.
+            child_for_size = (
+                value_child
+                if kind == "continuous"
+                else (len(self.layer_sizes) - 1 if self.layer_sizes else None)
+            )
+            if child_for_size is not None and self.layer_sizes[child_for_size] != size:
                 raise ValueError(
                     f"One-to-one layers require the same size as the child "
-                    f"layer ({self.layer_sizes[-1]}), got {size}."
+                    f"layer ({self.layer_sizes[child_for_size]}), got {size}."
                 )
 
         self.layer_sizes.append(size)
@@ -522,6 +674,11 @@ class DeepNetwork:
             coupling_fn if coupling_fn is not None else self.coupling_fn
         )
         self.volatility_parents.append(volatility_parent)
+        self.value_children.append(value_child)
+        self.volatility_children.append(volatility_child)
+        self.value_couplings.append(float(value_coupling))
+        self.volatility_couplings.append(float(volatility_coupling))
+        self.volatility_fully_connected.append(bool(volatility_fully_connected))
         # Eagerly rebuild the Network so ``self.state`` is always queryable
         # after construction. Cheap for typical depths; only triggers fresh
         # array allocations, no JIT trace.
@@ -531,6 +688,85 @@ class DeepNetwork:
         self.opt_state = None
         self._optimizer = None
         return self
+
+    def _resolve_continuous_children(
+        self,
+        *,
+        kind: str,
+        size: int,
+        value_children: Optional[int],
+        volatility_children: Optional[int],
+        volatility_fully_connected: bool,
+    ) -> tuple[Optional[int], Optional[int]]:
+        """Validate and resolve the child indices of a new continuous layer.
+
+        Returns ``(value_child, volatility_child)`` — the indices of the layers the new
+        layer is the value / volatility parent of, applying the chain default (previous
+        layer becomes the value child) when neither parent argument names a layer
+        explicitly.
+        """
+        if kind != "continuous":
+            return None, None
+
+        n_existing = len(self.layer_sizes)
+        if value_children is None and volatility_children is None:
+            value_child = n_existing - 1 if n_existing else None
+        else:
+            value_child = value_children
+        volatility_child = volatility_children
+
+        for name, child in (
+            ("value_children", value_child),
+            ("volatility_children", volatility_child),
+        ):
+            if child is None:
+                continue
+            if not 0 <= int(child) < n_existing:
+                raise IndexError(
+                    f"{name}={child} does not name an existing layer "
+                    f"(network has {n_existing} layers)."
+                )
+
+        if value_child is not None and value_child in self.value_children:
+            raise ValueError(
+                f"Layer {value_child} already has a value parent "
+                f"(layer {self.value_children.index(value_child)})."
+            )
+        if (
+            volatility_child is not None
+            and volatility_child in self.volatility_children
+        ):
+            raise ValueError(
+                f"Layer {volatility_child} already has a volatility parent "
+                f"(layer {self.volatility_children.index(volatility_child)})."
+            )
+
+        if volatility_child is not None:
+            child_size = self.layer_sizes[volatility_child]
+            if not volatility_fully_connected and child_size != size:
+                raise ValueError(
+                    f"A one-to-one volatility coupling requires equal sizes "
+                    f"(child layer {volatility_child} has {child_size} nodes, "
+                    f"this layer {size})."
+                )
+            if self.volatility_updates == "unbounded":
+                # The unbounded update is derived for a single volatility
+                # child per node and ignores value children.
+                if volatility_fully_connected and not (size == 1 and child_size == 1):
+                    raise ValueError(
+                        "The 'unbounded' volatility update requires a "
+                        "one-to-one volatility coupling "
+                        "(volatility_fully_connected=False). Use 'standard' "
+                        "or 'eHGF' for fully connected volatility parents."
+                    )
+                if value_child is not None:
+                    raise ValueError(
+                        "Under the 'unbounded' volatility update a volatility "
+                        "parent cannot also be a value parent. Use 'standard' "
+                        "or 'eHGF' for mixed parents."
+                    )
+
+        return value_child, volatility_child
 
     def add_layer_stack(
         self,
@@ -578,7 +814,8 @@ class DeepNetwork:
             Self for method chaining.
         """
         auto_scan = (
-            len(layer_sizes) >= _SCAN_AUTO_THRESHOLD
+            kind == "volatile"
+            and len(layer_sizes) >= _SCAN_AUTO_THRESHOLD
             and len(set(layer_sizes)) == 1
             and len(self.layer_sizes) > 0
             and self.layer_sizes[-1] == layer_sizes[0]
@@ -609,6 +846,9 @@ class DeepNetwork:
         All inter-layer weights are set to ``1.0``. Use :meth:`weight_initialisation`
         after construction to apply Xavier, He, orthogonal, or sparse initialisation.
         """
+        if self._is_continuous:
+            return self._init_continuous_state()
+
         layers: list[Layer] = []
 
         for i, size in enumerate(self.layer_sizes):
@@ -692,6 +932,116 @@ class DeepNetwork:
             feedforward_uncertainty=self.feedforward_uncertainty,
         )
 
+    def _fan_in_matrix(
+        self,
+        child: Optional[int],
+        size: int,
+        strength: float,
+        dense: bool,
+    ) -> Optional[jnp.ndarray]:
+        """Build one fixed coupling matrix of a continuous layer, or ``None``.
+
+        Used for both W (``value_coupling``) and κ (``volatility_coupling``). Dense
+        entries are ``strength / size``, so what the child receives — the drift or the
+        phasic volatility — is the base strength times the *average* of this layer,
+        invariant to its width. One-to-one edges have fan-in 1 and keep the base
+        strength on the diagonal.
+        """
+        if child is None:
+            return None
+        child_size = self.layer_sizes[child]
+        if dense:
+            return jnp.full((child_size, size), strength / size)
+        return strength * jnp.eye(child_size, size)
+
+    def _init_continuous_state(self) -> Network:
+        """Build the ``Network`` PyTree of an all-continuous network.
+
+        Both coupling matrices are fixed at construction and share the fan-in rule of
+        :meth:`_fan_in_matrix`.
+        """
+        n = len(self.layer_sizes)
+        has_vol_parent = [False] * n
+        for j in range(n):
+            child = self.volatility_children[j]
+            if child is not None:
+                has_vol_parent[child] = True
+
+        layers: list[Layer] = []
+        for i, size in enumerate(self.layer_sizes):
+            overrides = self.layer_overrides[i]
+
+            state = LayerState.create_continuous(
+                size, has_volatility_parent=has_vol_parent[i]
+            )
+            # Only fields the continuous state allocates can be overridden; the
+            # internal-volatility fields stay ``None``.
+            state_overrides = {
+                k: jnp.full(size, v)
+                for k, v in overrides.items()
+                if k in _LAYER_STATE_FIELDS and getattr(state, k) is not None
+            }
+            if state_overrides:
+                state = dataclasses.replace(state, **state_overrides)
+
+            param_kwargs = {}
+            if i == 0:
+                # Observation-leaf convention, mirroring the nodalised backend
+                # (``Network.input_idxs``): a clamped leaf performs no
+                # autoregression of its own and its volatility exponent is
+                # zeroed, so the observation noise is 1/exp(0) plus whatever a
+                # volatility parent contributes. Overridable per layer.
+                param_kwargs.update({
+                    "autoconnection_strength": 0.0,
+                    "tonic_volatility": 0.0,
+                })
+            param_kwargs.update({
+                k: v for k, v in overrides.items() if k in _CONTINUOUS_PARAM_FIELDS
+            })
+            params = LayerParams.create_continuous(n_nodes=size, **param_kwargs)
+
+            value_child = self.value_children[i]
+            weights_in = self._fan_in_matrix(
+                child=value_child,
+                size=size,
+                strength=self.value_couplings[i],
+                dense=self.fully_connected[i],
+            )
+            volatility_child = self.volatility_children[i]
+            volatility_weights_in = self._fan_in_matrix(
+                child=volatility_child,
+                size=size,
+                strength=self.volatility_couplings[i],
+                dense=self.volatility_fully_connected[i],
+            )
+
+            layers.append(
+                Layer(
+                    state=state,
+                    params=params,
+                    weights_in=weights_in,
+                    coupling_fn=self.coupling_fns[i],
+                    add_constant_input=False,
+                    has_volatility_parent=has_vol_parent[i],
+                    is_input_layer=(i == 0),
+                    fully_connected=self.fully_connected[i],
+                    kind="continuous",
+                    value_child_idx=value_child,
+                    volatility_child_idx=volatility_child,
+                    volatility_weights_in=volatility_weights_in,
+                )
+            )
+
+        return Network(
+            layers=tuple(layers),
+            volatility_updates=self.volatility_updates,
+            max_posterior_precision=self.max_posterior_precision,
+            precision_clipping_value=self.precision_clipping_value,
+            update_input_layer=self.update_input_layer,
+            predict_precision=self.predict_precision,
+            feedforward_uncertainty=self.feedforward_uncertainty,
+        )
+
     def _ensure_optimizer_state(
         self, optimizer: Optional[optax.GradientTransformation]
     ) -> None:
@@ -751,6 +1101,7 @@ class DeepNetwork:
         """
         if strategy is None:
             return self
+        self._require_deep_backend("weight_initialisation")
 
         valid = {"xavier", "he", "orthogonal", "sparse"}
         if strategy not in valid:
@@ -817,6 +1168,99 @@ class DeepNetwork:
         self.state = dataclasses.replace(self.state, layers=tuple(new_elements))
         return self
 
+    def _require_deep_backend(self, method: str) -> None:
+        """Reject deep-network entry points on a continuous network."""
+        if self._is_continuous:
+            raise ValueError(
+                f"{method}() is not available for continuous networks: they "
+                "are filters, not trainable deep networks. Use input_data() "
+                "to run observations through the network."
+            )
+
+    def input_data(
+        self,
+        input_data: Union[np.ndarray, jnp.ndarray],
+        time_steps: Optional[Union[np.ndarray, jnp.ndarray]] = None,
+        record: Optional[tuple] = None,
+    ) -> "DeepNetwork":
+        r"""Filter a sequence of observations through a continuous network.
+
+        The vectorized equivalent of
+        :meth:`pyhgf.model.network.Network.input_data`: for every observation,
+        the top-down prediction sweep advances every layer's expected mean and
+        precisions, the observation is clamped on layer 0, and the bottom-up
+        sweep propagates prediction errors through the value- and
+        volatility-coupling edges. Continuous networks only.
+
+        Parameters
+        ----------
+        input_data :
+            Observations for layer 0, shape ``(T, n_obs)`` (or ``(T,)`` when
+            layer 0 has a single node).
+        time_steps :
+            Per-step time steps :math:`\Delta t`, shape ``(T,)``. Defaults to
+            ``1.0`` everywhere.
+        record :
+            Tuple of ``LayerState`` field names to record at every time step,
+            as in :meth:`fit`; the result lands in ``self.trajectories``.
+            ``None`` (default) records nothing and only the per-step
+            predictions are kept in ``self.predictions``.
+
+        Returns
+        -------
+        DeepNetwork
+            Self, with ``self.state`` advanced by the whole sequence.
+        """
+        if not self._is_continuous:
+            raise ValueError(
+                "input_data() is only available for continuous networks; use "
+                "fit() for volatile/binary/categorical networks."
+            )
+        assert self.state is not None
+
+        record_tuple: tuple = tuple(record) if record else ()
+        if record_tuple:
+            # Only fields this network actually allocates can be recorded — a
+            # continuous layer leaves the internal-volatility fields at ``None``,
+            # so asking for them would silently record nothing.
+            valid_fields = {
+                name
+                for name in LayerState.__dataclass_fields__
+                if any(
+                    getattr(elem.state, name) is not None for elem in self.state.layers
+                )
+            }
+            invalid = [f for f in record_tuple if f not in valid_fields]
+            if invalid:
+                raise ValueError(
+                    f"Unknown record field(s) {invalid}. Valid: {sorted(valid_fields)}."
+                )
+
+        y = jnp.asarray(input_data)
+        if y.ndim == 1:
+            y = y[:, None]
+        if y.shape[1] != self.layer_sizes[0]:
+            raise ValueError(
+                f"input_data has {y.shape[1]} features but layer 0 has "
+                f"{self.layer_sizes[0]} nodes."
+            )
+        if time_steps is None:
+            time_steps = jnp.ones(y.shape[0])
+        else:
+            time_steps = jnp.asarray(time_steps)
+
+        self.state, step_output = run_continuous_scan(
+            self.state, y, time_steps, record_tuple
+        )
+
+        if record_tuple:
+            self.trajectories, self.predictions = step_output
+        else:
+            self.trajectories = None
+            self.predictions = step_output
+
+        return self
+
     def fit(
         self,
         x: Union[np.ndarray, jnp.ndarray],
@@ -876,6 +1320,7 @@ class DeepNetwork:
         DeepNetwork
             Self with updated state and optimiser state.
         """
+        self._require_deep_backend("fit")
         if self.state is None:
             raise ValueError("Add at least one layer before calling fit.")
 
@@ -1031,6 +1476,7 @@ class DeepNetwork:
         jnp.ndarray
             Predictions, shape (n_samples, n_output_features) or (n_output_features,).
         """
+        self._require_deep_backend("predict")
         if self.state is None:
             raise ValueError("Add at least one layer before calling predict.")
 
@@ -1065,6 +1511,7 @@ class DeepNetwork:
         DeepNetwork
             Self, with ``self.state`` advanced by the prediction sweep.
         """
+        self._require_deep_backend("prediction")
         if self.state is None:
             raise ValueError("Add at least one layer before calling prediction.")
         x = jnp.asarray(x)
@@ -1119,6 +1566,7 @@ class DeepNetwork:
         DeepNetwork
             Self, with ``self.state`` (and, if learning, ``self.opt_state``) advanced.
         """
+        self._require_deep_backend("update")
         if self.state is None:
             raise ValueError("Add at least one layer before calling update.")
         y = jnp.asarray(y)
@@ -1155,6 +1603,7 @@ class DeepNetwork:
             The prediction error at the top layer, shape
             ``(n_input_features,)``.
         """
+        self._require_deep_backend("input_error")
         if self.state is None:
             raise ValueError("Add at least one layer before calling input_error.")
         return input_prediction_error(self.state)
@@ -1183,6 +1632,7 @@ class DeepNetwork:
             One batched ``LayerState`` per element — an opaque value to hand
             back to :meth:`batch_update`.
         """
+        self._require_deep_backend("predict_states")
         if self.state is None:
             raise ValueError("Add at least one layer before calling predict_states.")
         states = batched_prediction_states(self.state, jnp.asarray(x))
@@ -1248,6 +1698,7 @@ class DeepNetwork:
             Self, with ``self.state`` (and, if learning, ``self.opt_state``)
             advanced by one batch.
         """
+        self._require_deep_backend("batch_update")
         if self.state is None:
             raise ValueError("Add at least one layer before calling batch_update.")
         x = jnp.asarray(x)

--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -101,6 +101,28 @@ class LayerState(eqx.Module):
             volatility_prediction_error=vol(0.0),
         )
 
+    @classmethod
+    def create_continuous(
+        cls, n_nodes: int, has_volatility_parent: bool = False
+    ) -> "LayerState":
+        """Initialise the state of a layer of regular continuous nodes."""
+        vope = jnp.zeros(n_nodes) if has_volatility_parent else None
+        return cls(
+            mean=jnp.zeros(n_nodes),
+            precision=jnp.ones(n_nodes),
+            expected_mean=jnp.zeros(n_nodes),
+            expected_precision=jnp.ones(n_nodes),
+            conditional_expected_precision=jnp.ones(n_nodes),
+            effective_precision=jnp.zeros(n_nodes),
+            value_prediction_error=jnp.zeros(n_nodes),
+            mean_vol=None,
+            precision_vol=None,
+            expected_mean_vol=None,
+            expected_precision_vol=None,
+            effective_precision_vol=None,
+            volatility_prediction_error=vope,
+        )
+
 
 # The six volatility-level fields of :class:`LayerState`, set to ``None`` on a
 # layer without a volatility parent (see :meth:`LayerState.create`).
@@ -115,17 +137,33 @@ VOLATILITY_STATE_FIELDS: tuple = (
 
 
 class LayerParams(eqx.Module):
-    """Per-layer static parameters.
+    r"""Per-layer static parameters.
 
-    Each field is an array with one entry per node in the layer.
+    Each field is an array with one entry per node in the layer, or ``None`` when
+    the field does not apply to the layer's kind: volatile layers carry
+    ``tonic_volatility_vol`` only, continuous layers carry the other three.
 
     Parameters
     ----------
     tonic_volatility_vol :
-        The tonic (baseline) volatility of the volatility level.
+        The tonic (baseline) volatility of the implied internal volatility level
+        (volatile layers only).
+    tonic_volatility :
+        The tonic (baseline) log-volatility :math:`\omega` of the node's own
+        Gaussian random walk (continuous layers only).
+    tonic_drift :
+        The constant drift :math:`\rho` added to the predicted mean at every
+        time step (continuous layers only).
+    autoconnection_strength :
+        The AR(1) coefficient :math:`\lambda \in [0, 1]` on the node's own mean
+        in the prediction; ``1.0`` is a pure random walk (continuous layers
+        only).
     """
 
-    tonic_volatility_vol: Array
+    tonic_volatility_vol: Optional[Array] = None
+    tonic_volatility: Optional[Array] = None
+    tonic_drift: Optional[Array] = None
+    autoconnection_strength: Optional[Array] = None
 
     @classmethod
     def create(
@@ -133,14 +171,29 @@ class LayerParams(eqx.Module):
         n_nodes: int,
         tonic_volatility_vol: float = -4.0,
     ) -> "LayerParams":
-        """Initialise layer params with defaults."""
+        """Initialise volatile-layer params with defaults."""
         return cls(
             tonic_volatility_vol=jnp.full(n_nodes, tonic_volatility_vol),
         )
 
+    @classmethod
+    def create_continuous(
+        cls,
+        n_nodes: int,
+        tonic_volatility: float = -4.0,
+        tonic_drift: float = 0.0,
+        autoconnection_strength: float = 1.0,
+    ) -> "LayerParams":
+        """Initialise continuous-layer params with the nodalised defaults."""
+        return cls(
+            tonic_volatility=jnp.full(n_nodes, tonic_volatility),
+            tonic_drift=jnp.full(n_nodes, tonic_drift),
+            autoconnection_strength=jnp.full(n_nodes, autoconnection_strength),
+        )
+
 
 class Layer(eqx.Module):
-    """One layer of the vectorised deep network.
+    r"""One layer of the vectorised deep network.
 
     ``weights_in`` is the matrix connecting the layer *below* (child) into this layer
     (parent). The bottom layer (index 0) has ``weights_in=None`` because no layer sits
@@ -167,7 +220,23 @@ class Layer(eqx.Module):
     fully_connected :
         Whether the incoming weights are fully connected.
     kind :
-        The kind of layer, one of ``"volatile"``, ``"binary"``, or ``"categorical"``.
+        The kind of layer, one of ``"volatile"``, ``"binary"``, ``"categorical"``,
+        or ``"continuous"``.
+    value_child_idx :
+        Continuous layers only — index (into ``Network.layers``) of the layer this
+        layer is the *value parent* of, or ``None``. ``weights_in`` then connects
+        that child into this layer, shape ``(n_child, n_self)``, and enters the
+        drift of the child's predicted mean. The chain convention of volatile
+        networks (``weights_in`` always connects the layer directly below) is a
+        special case with ``value_child_idx = self_index - 1``.
+    volatility_child_idx :
+        Continuous layers only — index of the layer this layer is the *volatility
+        parent* of, or ``None``. ``volatility_weights_in`` connects that child.
+    volatility_weights_in :
+        Volatility-coupling matrix :math:`\kappa`, shape ``(n_child, n_self)``,
+        connecting the volatility child named by ``volatility_child_idx`` into
+        this layer. Fixed at construction — never part of the learned weights
+        (excluded from :meth:`Network.weights_tuple`).
     """
 
     state: LayerState
@@ -178,7 +247,12 @@ class Layer(eqx.Module):
     has_volatility_parent: bool = field(static=True)
     is_input_layer: bool = field(static=True)
     fully_connected: bool = field(static=True)
-    kind: str = field(static=True)  # "volatile" | "binary" | "categorical"
+    kind: str = field(
+        static=True
+    )  # "volatile" | "binary" | "categorical" | "continuous"
+    value_child_idx: Optional[int] = field(static=True, default=None)
+    volatility_child_idx: Optional[int] = field(static=True, default=None)
+    volatility_weights_in: Optional[Array] = None
 
 
 class LayerStack(eqx.Module):
@@ -238,6 +312,10 @@ def stack_layers(layers: list) -> LayerStack:
     add_constant_input, has_volatility_parent, fully_connected) and have ``weights_in``
     of identical shape. Static fields are taken from the first layer; arrays are stacked
     along a new axis 0.
+
+    A ``LayerStack`` carries no DAG topology, so the continuous-layer fields
+    (``value_child_idx``, ``volatility_child_idx``, ``volatility_weights_in``) have no
+    counterpart here and continuous layers cannot be stacked.
 
     Parameters
     ----------

--- a/pyhgf/updates/vectorized/continuous/__init__.py
+++ b/pyhgf/updates/vectorized/continuous/__init__.py
@@ -1,0 +1,38 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Vectorized update functions for layers of regular continuous nodes.
+
+Layer-wise vectorized implementations of the continuous HGF update equations (standard
+drift semantics), with the value and volatility parents generalised to fully connected
+layers. Mirrors :mod:`pyhgf.updates.prediction.continuous`,
+:mod:`pyhgf.updates.prediction_error.continuous`, and
+:mod:`pyhgf.updates.posterior.continuous`.
+"""
+
+from .posterior import (
+    ValueChild,
+    VolatilityChild,
+    vectorized_continuous_posterior_update,
+    vectorized_continuous_posterior_update_ehgf,
+    vectorized_continuous_posterior_update_standard,
+    vectorized_continuous_posterior_update_unbounded,
+)
+from .prediction import vectorized_continuous_prediction
+from .prediction_error import (
+    vectorized_continuous_prediction_error,
+    vectorized_continuous_value_prediction_error,
+    vectorized_continuous_volatility_prediction_error,
+)
+
+__all__ = [
+    "ValueChild",
+    "VolatilityChild",
+    "vectorized_continuous_posterior_update",
+    "vectorized_continuous_posterior_update_ehgf",
+    "vectorized_continuous_posterior_update_standard",
+    "vectorized_continuous_posterior_update_unbounded",
+    "vectorized_continuous_prediction",
+    "vectorized_continuous_prediction_error",
+    "vectorized_continuous_value_prediction_error",
+    "vectorized_continuous_volatility_prediction_error",
+]

--- a/pyhgf/updates/vectorized/continuous/posterior.py
+++ b/pyhgf/updates/vectorized/continuous/posterior.py
@@ -1,0 +1,623 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+r"""Vectorized posterior updates for layers of regular continuous nodes.
+
+This module mirrors :mod:`pyhgf.updates.posterior.continuous` for vectorized
+layers. A continuous layer can be the *value parent* of one layer (connected by a
+weight matrix :math:`W` entering the child's drift) and/or the *volatility parent*
+of one layer (connected by a fixed coupling matrix :math:`\kappa` entering the
+child's log-volatility); its posterior update integrates the prediction errors of
+both children.
+
+Three update schemes are provided, matching the nodalised backend's dispatch in
+:func:`pyhgf.utils.get_update_sequence.get_update_sequence`: layers without a
+volatility child always use the standard update; layers with one dispatch on
+``volatility_updates`` (``"standard"``, ``"eHGF"``, or ``"unbounded"``).
+"""
+
+import dataclasses
+from typing import Callable, NamedTuple, Optional
+
+import jax.numpy as jnp
+from jax import grad, vmap
+from jax.nn import sigmoid
+
+from pyhgf.math import lambert_w0
+from pyhgf.typing.vectorised import LayerParams, LayerState
+
+
+class ValueChild(NamedTuple):
+    """The value child of a continuous layer, as seen by its posterior update.
+
+    Parameters
+    ----------
+    state :
+        The child layer's state, already carrying its posterior and
+        ``value_prediction_error``.
+    weights :
+        The value-coupling matrix connecting the child into the parent, shape
+        ``(n_child, n_parent)``.
+    coupling_fn :
+        The coupling function on the edge.
+    precision_is_clamped :
+        Whether the child's posterior precision is never updated — true for the
+        clamped observation leaf. The smoothing (structured-Gaussian) factors
+        then collapse to the canonical predicted precision; see
+        :func:`_smoothing_factors`.
+    """
+
+    state: LayerState
+    weights: jnp.ndarray
+    coupling_fn: Callable
+    precision_is_clamped: bool
+
+
+class VolatilityChild(NamedTuple):
+    """The volatility child of a continuous layer, as seen by its posterior update.
+
+    Parameters
+    ----------
+    state :
+        The child layer's state, already carrying its posterior and
+        ``volatility_prediction_error``.
+    kappa :
+        The volatility-coupling matrix, shape ``(n_child, n_parent)``.
+    params :
+        The child layer's parameters (``tonic_volatility`` is read by the eHGF
+        and unbounded updates).
+    """
+
+    state: LayerState
+    kappa: jnp.ndarray
+    params: LayerParams
+
+
+# ---------------------------------------------------------------------------
+# Shared building blocks
+# ---------------------------------------------------------------------------
+
+
+def _smoothing_factors(child: ValueChild) -> tuple[jnp.ndarray, jnp.ndarray]:
+    r"""Child-precision factors weighting the value messages sent to the parent.
+
+    Returns ``(effective_precision, gain)`` — the factors multiplying the child's
+    prediction error in :func:`_value_precision_pwpe` and :func:`_value_mean_pwpe`
+    respectively. Both are structured-Gaussian (RTS-smoother) forms sharing a
+    denominator:
+
+    .. math::
+
+        \pi^{\mathrm{eff}}_a = \frac{\hat{\pi}_a \, \pi^y_a}{\hat{\pi}_a + \pi^y_a},
+        \qquad
+        g_a = \frac{\hat{\pi}_a \, \pi_a}{\hat{\pi}_a + \pi^y_a},
+        \qquad
+        \pi^y_a = \pi_a - \tilde{\pi}_a.
+
+    When the child's posterior precision is clamped there is no smoothing
+    correction to make, and both collapse to the canonical predicted precision
+    :math:`\tilde{\pi}_a`.
+    """
+    if child.precision_is_clamped:
+        return child.state.expected_precision, child.state.expected_precision
+
+    conditional = child.state.conditional_expected_precision
+    pi_y = child.state.precision - child.state.expected_precision
+    denominator = conditional + pi_y
+    return conditional * pi_y / denominator, conditional * child.state.precision / (
+        denominator
+    )
+
+
+def _value_precision_pwpe(
+    eval_mean: jnp.ndarray,
+    child: ValueChild,
+) -> jnp.ndarray:
+    r"""Value-coupling precision-weighted prediction error (eq.
+
+    50 form).
+        Per parent node :math:`m`:
+
+        .. math::
+
+            \sum_a \pi_a^{\mathrm{eff}} \left( W_{a,m}^2 \, g'(\mu_m)^2
+                - W_{a,m} \, g''(\mu_m) \, \delta_a \right),
+
+        with :math:`\pi^{\mathrm{eff}}_a` from :func:`_smoothing_factors`. Derivatives
+        are evaluated at *eval_mean* — the parent's previous posterior mean in the
+        standard scheme, its freshly updated posterior mean in the eHGF scheme
+        (which updates the mean first), mirroring the nodalised call order.
+    """
+    effective_child_precision, _ = _smoothing_factors(child)
+
+    coupling_prime = vmap(grad(child.coupling_fn))(eval_mean)
+    coupling_second = vmap(grad(grad(child.coupling_fn)))(eval_mean)
+
+    first_order = jnp.matmul(child.weights.T**2, effective_child_precision) * (
+        coupling_prime**2
+    )
+    second_order = -coupling_second * jnp.matmul(
+        child.weights.T,
+        effective_child_precision * child.state.value_prediction_error,
+    )
+    return first_order + second_order
+
+
+def _value_mean_pwpe(
+    eval_mean: jnp.ndarray,
+    child: ValueChild,
+    node_precision: jnp.ndarray,
+) -> jnp.ndarray:
+    r"""Value-coupling mean shift, accumulated across child nodes.
+
+    .. math::
+
+        \Delta \mu_m = \frac{g'(\mu_m)}{\pi_m}
+            \sum_a W_{a,m} \, g_a \, \delta_a,
+
+    with the joint-Gaussian gain :math:`g_a` from :func:`_smoothing_factors`.
+    """
+    _, gain = _smoothing_factors(child)
+
+    coupling_prime = vmap(grad(child.coupling_fn))(eval_mean)
+    return (
+        jnp.matmul(child.weights.T, gain * child.state.value_prediction_error)
+        * coupling_prime
+        / node_precision
+    )
+
+
+def _volatility_precision_pwpe_standard(child: VolatilityChild) -> jnp.ndarray:
+    r"""Compute the standard volatility-coupling precision increment.
+
+    Per (child :math:`a`, parent :math:`m`) edge:
+    :math:`\tfrac12 (\kappa \gamma)^2 + (\kappa \gamma)^2 \Delta
+    - \tfrac12 \kappa^2 \gamma \Delta`, with :math:`\gamma` the child's
+    effective precision from the prediction step and :math:`\Delta` its
+    volatility prediction error.
+    """
+    gamma = child.state.effective_precision
+    delta = child.state.volatility_prediction_error
+    kappa_sq = child.kappa**2
+    return (
+        0.5 * jnp.matmul(kappa_sq.T, gamma**2)
+        + jnp.matmul(kappa_sq.T, gamma**2 * delta)
+        - 0.5 * jnp.matmul(kappa_sq.T, gamma * delta)
+    )
+
+
+def _volatility_mean_pwpe(
+    child: VolatilityChild,
+    node_precision: jnp.ndarray,
+) -> jnp.ndarray:
+    r"""Volatility-coupling mean shift, accumulated across child nodes.
+
+    .. math::
+
+        \Delta \mu_m = \frac{1}{2 \pi_m} \sum_a \kappa_{a,m} \,
+            \gamma_a \, \Delta_a.
+    """
+    return jnp.matmul(
+        child.kappa.T,
+        child.state.effective_precision * child.state.volatility_prediction_error,
+    ) / (2.0 * node_precision)
+
+
+def _child_previous_variance(
+    layer: LayerState,
+    child: VolatilityChild,
+    time_step: float,
+) -> jnp.ndarray:
+    r"""Reconstruct the volatility child's previous-step posterior variance.
+
+    The prediction step set
+    :math:`1 / \hat{\pi}_a = 1 / \pi_a^{(k-1)} + \Omega_a` with the full
+    predicted volatility :math:`\Omega_a` (volatility-parent contribution and
+    MGF correction included), so subtracting the same :math:`\Omega_a` from the
+    inverse *conditional* predicted precision cancels back to
+    :math:`1 / \pi_a^{(k-1)}` — the quantity the nodalised backend stores as
+    ``temp["current_variance"]``. The parent's prediction-time
+    ``expected_mean`` / ``expected_precision`` are still intact when the
+    posterior update runs, so the reconstruction is exact.
+    """
+    assert child.params.tonic_volatility is not None
+    total_volatility = (
+        child.params.tonic_volatility
+        + jnp.matmul(child.kappa, layer.expected_mean)
+        + jnp.matmul(child.kappa**2, 1.0 / (2.0 * layer.expected_precision))
+    )
+    predicted_volatility = time_step * jnp.exp(total_volatility)
+    return jnp.maximum(
+        1.0 / child.state.conditional_expected_precision - predicted_volatility,
+        1e-128,
+    )
+
+
+def _volatility_precision_pwpe_ehgf(
+    posterior_mean: jnp.ndarray,
+    layer: LayerState,
+    child: VolatilityChild,
+    time_step: float,
+) -> jnp.ndarray:
+    r"""Enhanced-HGF "safe" volatility-coupling precision increment.
+
+    Mirrors
+    :func:`pyhgf.updates.posterior.continuous.posterior_update_precision_continuous_node._ehgf_volatility_precision_increment`:
+    the child's volatility is re-predicted from the parent's *just-updated*
+    posterior mean through each :math:`\kappa_{a,m}` edge alone (single-parent
+    linearisation, no MGF term), and each edge's increment
+    :math:`\tfrac12 \kappa^2 \gamma (\gamma + w \Delta)` is floored at zero
+    before summation, so the posterior precision can never fall below the
+    predicted precision.
+    """
+    assert child.params.tonic_volatility is not None
+    previous_variance = _child_previous_variance(layer, child, time_step)
+
+    # Per-edge re-prediction, shape (n_child, n_parent).
+    predicted_volatility = time_step * jnp.exp(
+        child.kappa * posterior_mean[None, :] + child.params.tonic_volatility[:, None]
+    )
+    expected_precision = 1.0 / (previous_variance[:, None] + predicted_volatility)
+    effective_precision = predicted_volatility * expected_precision
+    volatility_error_weight = (
+        predicted_volatility - previous_variance[:, None]
+    ) * expected_precision
+    volatility_prediction_error = (
+        1.0 / child.state.precision
+        + (child.state.mean - child.state.expected_mean) ** 2
+    )[:, None] * expected_precision - 1.0
+
+    increment = jnp.maximum(
+        0.0,
+        0.5
+        * child.kappa**2
+        * effective_precision
+        * (effective_precision + volatility_error_weight * volatility_prediction_error),
+    )
+    return increment.sum(axis=0)
+
+
+def _finalize_precision(
+    expected_precision: jnp.ndarray,
+    pwpe: jnp.ndarray,
+    max_posterior_precision: float,
+) -> jnp.ndarray:
+    """Add the precision-weighted PE, guard positivity, and apply the cap."""
+    posterior_precision = expected_precision + pwpe
+    posterior_precision = jnp.where(
+        posterior_precision > 1e-128, posterior_precision, jnp.nan
+    )
+    return jnp.minimum(posterior_precision, max_posterior_precision)
+
+
+# ---------------------------------------------------------------------------
+# Update schemes
+# ---------------------------------------------------------------------------
+
+
+def vectorized_continuous_posterior_update_standard(
+    layer: LayerState,
+    value_child: Optional[ValueChild] = None,
+    volatility_child: Optional[VolatilityChild] = None,
+    max_posterior_precision: float = 1e10,
+) -> LayerState:
+    """Apply the standard HGF posterior update: precision first, then the mean.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.posterior.continuous.continuous_node_posterior_update`.
+
+    Parameters
+    ----------
+    layer :
+        The parent layer's state (being updated).
+    value_child :
+        The value child, or ``None``.
+    volatility_child :
+        The volatility child, or ``None``.
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with posterior ``precision`` and ``mean``.
+    """
+    eval_mean = layer.mean  # previous posterior mean
+
+    pwpe = jnp.zeros_like(layer.precision)
+    if value_child is not None:
+        pwpe = pwpe + _value_precision_pwpe(eval_mean, value_child)
+    if volatility_child is not None:
+        pwpe = pwpe + _volatility_precision_pwpe_standard(volatility_child)
+    posterior_precision = _finalize_precision(
+        layer.expected_precision, pwpe, max_posterior_precision
+    )
+
+    mean_pwpe = jnp.zeros_like(layer.mean)
+    if value_child is not None:
+        mean_pwpe = mean_pwpe + _value_mean_pwpe(
+            eval_mean, value_child, posterior_precision
+        )
+    if volatility_child is not None:
+        mean_pwpe = mean_pwpe + _volatility_mean_pwpe(
+            volatility_child, posterior_precision
+        )
+    posterior_mean = layer.expected_mean + mean_pwpe
+
+    return dataclasses.replace(
+        layer, precision=posterior_precision, mean=posterior_mean
+    )
+
+
+def vectorized_continuous_posterior_update_ehgf(
+    layer: LayerState,
+    value_child: Optional[ValueChild] = None,
+    volatility_child: Optional[VolatilityChild] = None,
+    time_step: float = 1.0,
+    max_posterior_precision: float = 1e10,
+) -> LayerState:
+    """Enhanced-HGF posterior update: mean first, then the safe precision.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.posterior.continuous.continuous_node_posterior_update_ehgf`:
+    the mean update approximates the node precision with the expected precision,
+    and the volatility-coupling precision increment is recomputed from the
+    posterior mean and floored at zero.
+
+    Parameters
+    ----------
+    layer :
+        The parent layer's state (being updated).
+    value_child :
+        The value child, or ``None``.
+    volatility_child :
+        The volatility child, or ``None``.
+    time_step :
+        Current time step (needed to re-predict the child's volatility).
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with posterior ``precision`` and ``mean``.
+    """
+    eval_mean = layer.mean  # previous posterior mean
+
+    mean_pwpe = jnp.zeros_like(layer.mean)
+    if value_child is not None:
+        mean_pwpe = mean_pwpe + _value_mean_pwpe(
+            eval_mean, value_child, layer.expected_precision
+        )
+    if volatility_child is not None:
+        mean_pwpe = mean_pwpe + _volatility_mean_pwpe(
+            volatility_child, layer.expected_precision
+        )
+    posterior_mean = layer.expected_mean + mean_pwpe
+
+    # The nodalised backend writes the mean before the precision update, so the
+    # value-coupling derivatives are evaluated at the *new* posterior mean.
+    pwpe = jnp.zeros_like(layer.precision)
+    if value_child is not None:
+        pwpe = pwpe + _value_precision_pwpe(posterior_mean, value_child)
+    if volatility_child is not None:
+        pwpe = pwpe + _volatility_precision_pwpe_ehgf(
+            posterior_mean, layer, volatility_child, time_step
+        )
+    posterior_precision = _finalize_precision(
+        layer.expected_precision, pwpe, max_posterior_precision
+    )
+
+    return dataclasses.replace(
+        layer, precision=posterior_precision, mean=posterior_mean
+    )
+
+
+def vectorized_continuous_posterior_update_unbounded(
+    layer: LayerState,
+    volatility_child: VolatilityChild,
+    time_step: float = 1.0,
+    max_posterior_precision: float = 1e10,
+) -> LayerState:
+    """Unbounded posterior update for a pure volatility-parent layer.
+
+    Vectorized port of
+    :func:`pyhgf.updates.posterior.continuous.continuous_node_posterior_update_unbounded`
+    (Lambert :math:`W_0` dual-quadratic expansion with a variational
+    energy-based blend). The approximation is derived for a single volatility
+    child per node, so the coupling must be one-to-one: ``kappa`` square and
+    diagonal, each parent node coupled to exactly one child node. The layer must
+    have no value child (the nodalised update ignores value children; the
+    vectorized builder rejects such a topology instead of silently dropping the
+    edge).
+
+    Parameters
+    ----------
+    layer :
+        The parent layer's state (being updated).
+    volatility_child :
+        The volatility child, with a square diagonal ``kappa``.
+    time_step :
+        Current time step.
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with posterior ``precision`` and ``mean``.
+    """
+    child = volatility_child
+    assert child.kappa.shape[0] == child.kappa.shape[1], (
+        "The unbounded update requires a one-to-one (square, diagonal) "
+        "volatility coupling."
+    )
+    assert child.params.tonic_volatility is not None
+    kappa = jnp.diagonal(child.kappa)
+    tonic_volatility = child.params.tonic_volatility
+
+    previous_variance = _child_previous_variance(layer, child, time_step)
+    be_aux = (
+        1.0 / child.state.precision
+        + (child.state.mean - child.state.expected_mean) ** 2
+    )
+
+    expected_mean = layer.expected_mean
+    expected_precision = layer.expected_precision
+
+    # Log-space throughout: forming ``exp(γ)`` explicitly is forward-stable but
+    # injects 0·∞ NaNs in the backward pass; the sigmoid/logaddexp rewrites
+    # match the direct forms for every finite input and stay gradient-safe.
+    # Mirrors ``continuous_node_posterior_update_unbounded``.
+    log_time_step = jnp.log(time_step)
+    log_previous_variance = jnp.log(previous_variance)
+
+    # Canonical exponent at prediction:
+    # γ = log(time_step) + κ μ̂_parent + ω_child.
+    gamma_c = log_time_step + kappa * expected_mean + tonic_volatility
+
+    w_jm1 = sigmoid(gamma_c - log_previous_variance)
+    da_jm1 = child.state.expected_precision * be_aux - 1.0
+
+    # ------------------------------------------------------------------
+    # Expansion 1: quadratic at the prediction (prior mean)
+    # ------------------------------------------------------------------
+    pi1 = expected_precision + 0.5 * kappa**2 * w_jm1 * (1.0 - w_jm1)
+    mu1 = expected_mean + (kappa * w_jm1 / (2.0 * pi1)) * da_jm1
+
+    # ------------------------------------------------------------------
+    # Expansion 2: quadratic at the Lambert W₀ approximate mode
+    # ------------------------------------------------------------------
+    pihat_y = expected_precision / kappa**2
+
+    log_W_arg = jnp.log(be_aux) - jnp.log(2.0 * pihat_y) + 0.5 / pihat_y - gamma_c
+    log_float_max = jnp.log(jnp.finfo(jnp.result_type(log_W_arg)).max)
+    W_arg = jnp.exp(jnp.minimum(log_W_arg, log_float_max))
+    v_W = lambert_w0(W_arg)
+    y_star = gamma_c + v_W - 0.5 / pihat_y
+    x_star = (y_star - log_time_step - tonic_volatility) / kappa
+
+    log_s2 = log_time_step + kappa * x_star + tonic_volatility
+    log_denom_s = jnp.logaddexp(log_previous_variance, log_s2)
+    w2 = sigmoid(log_s2 - log_previous_variance)
+    da2 = be_aux * jnp.exp(-log_denom_s) - 1.0
+
+    pi2_full = expected_precision + 0.5 * kappa**2 * w2 * (w2 + (2.0 * w2 - 1.0) * da2)
+    pi2_safe = jnp.where(
+        pi2_full <= 0.0,
+        expected_precision + 0.5 * kappa**2 * w2 * (1.0 - w2),
+        pi2_full,
+    )
+    mu2_safe = (
+        x_star
+        + (0.5 * kappa * w2 * da2 - expected_precision * (x_star - expected_mean))
+        / pi2_safe
+    )
+
+    # Double-where masking: sanitise non-finite Expansion-2 results before the
+    # outer ``where`` so its VJP never does ``0 * NaN``.
+    exp2_finite = jnp.isfinite(pi2_safe) & jnp.isfinite(mu2_safe)
+    pi2_safe_for_grad = jnp.where(exp2_finite, pi2_safe, 1.0)
+    mu2_safe_for_grad = jnp.where(exp2_finite, mu2_safe, 0.0)
+    pi2 = jnp.where(exp2_finite, pi2_safe_for_grad, pi1)
+    mu2 = jnp.where(exp2_finite, mu2_safe_for_grad, mu1)
+
+    # ------------------------------------------------------------------
+    # Variational energy-based softmax blend (log-space, gradient-safe)
+    # ------------------------------------------------------------------
+    log_ey1 = log_time_step + kappa * mu1 + tonic_volatility
+    log_denom_1 = jnp.logaddexp(log_previous_variance, log_ey1)
+    I1 = (
+        -0.5 * log_denom_1
+        - 0.5 * be_aux * jnp.exp(-log_denom_1)
+        - 0.5 * expected_precision * (mu1 - expected_mean) ** 2
+    )
+
+    log_ey2 = log_time_step + kappa * mu2 + tonic_volatility
+    log_denom_2 = jnp.logaddexp(log_previous_variance, log_ey2)
+    I2 = (
+        -0.5 * log_denom_2
+        - 0.5 * be_aux * jnp.exp(-log_denom_2)
+        - 0.5 * expected_precision * (mu2 - expected_mean) ** 2
+    )
+
+    b = sigmoid(I2 - I1)
+
+    # ------------------------------------------------------------------
+    # Gaussian mixture moment matching
+    # ------------------------------------------------------------------
+    posterior_mean = (1.0 - b) * mu1 + b * mu2
+    sig2 = (1.0 - b) / pi1 + b / pi2 + b * (1.0 - b) * (mu1 - mu2) ** 2
+    posterior_precision = jnp.minimum(1.0 / sig2, max_posterior_precision)
+
+    return dataclasses.replace(
+        layer, precision=posterior_precision, mean=posterior_mean
+    )
+
+
+def vectorized_continuous_posterior_update(
+    layer: LayerState,
+    value_child: Optional[ValueChild] = None,
+    volatility_child: Optional[VolatilityChild] = None,
+    volatility_updates: str = "eHGF",
+    time_step: float = 1.0,
+    max_posterior_precision: float = 1e10,
+) -> LayerState:
+    """Dispatch the continuous posterior update on the layer's children.
+
+    Mirrors the assignment rule of
+    :func:`pyhgf.utils.get_update_sequence.get_update_sequence`: layers without
+    a volatility child always take the standard update; layers with one take
+    the update named by *volatility_updates*.
+
+    Parameters
+    ----------
+    layer :
+        The parent layer's state (being updated).
+    value_child :
+        The value child, or ``None``.
+    volatility_child :
+        The volatility child, or ``None``.
+    volatility_updates :
+        One of ``"standard"``, ``"eHGF"``, or ``"unbounded"``.
+    time_step :
+        Current time step.
+    max_posterior_precision :
+        Upper bound applied to the posterior precision write.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with posterior ``precision`` and ``mean``.
+    """
+    if volatility_child is None or volatility_updates == "standard":
+        return vectorized_continuous_posterior_update_standard(
+            layer,
+            value_child=value_child,
+            volatility_child=volatility_child,
+            max_posterior_precision=max_posterior_precision,
+        )
+    if volatility_updates == "eHGF":
+        return vectorized_continuous_posterior_update_ehgf(
+            layer,
+            value_child=value_child,
+            volatility_child=volatility_child,
+            time_step=time_step,
+            max_posterior_precision=max_posterior_precision,
+        )
+    if volatility_updates == "unbounded":
+        if value_child is not None:
+            raise ValueError(
+                "The unbounded update is derived for pure volatility parents; "
+                "this layer also has a value child. Use 'standard' or 'eHGF' "
+                "volatility updates for mixed parents."
+            )
+        return vectorized_continuous_posterior_update_unbounded(
+            layer,
+            volatility_child=volatility_child,
+            time_step=time_step,
+            max_posterior_precision=max_posterior_precision,
+        )
+    raise ValueError(
+        f"Invalid volatility_updates {volatility_updates!r}. "
+        "Choose from 'standard', 'eHGF', or 'unbounded'."
+    )

--- a/pyhgf/updates/vectorized/continuous/prediction.py
+++ b/pyhgf/updates/vectorized/continuous/prediction.py
@@ -1,0 +1,172 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Vectorized prediction update for layers of regular continuous nodes."""
+
+import dataclasses
+from typing import Callable, Optional
+
+import jax.numpy as jnp
+from jax import grad, vmap
+
+from pyhgf.typing.vectorised import LayerParams, LayerState
+
+
+def vectorized_continuous_prediction(
+    child_state: LayerState,
+    params: LayerParams,
+    time_step: float,
+    value_parent_state: Optional[LayerState] = None,
+    weights: Optional[jnp.ndarray] = None,
+    coupling_fn: Optional[Callable] = None,
+    volatility_parent_state: Optional[LayerState] = None,
+    volatility_weights: Optional[jnp.ndarray] = None,
+    is_static_leaf: bool = False,
+) -> LayerState:
+    r"""Predict expected mean and precisions for a layer of continuous nodes.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.prediction.continuous.continuous_node_prediction`, applied
+    to a whole layer at once with the value and volatility parents generalised to
+    *layers* connected by matrices.
+
+    The expected mean follows the standard HGF drift semantics,
+
+    .. math::
+
+        \hat{\mu}_a^{(k)} = \lambda_a \mu_a^{(k-1)}
+            + t^{(k)} \left( \rho_a + \sum_b W_{a,b} \, g(\hat{\mu}_b) \right),
+
+    so the value parent nudges the child's own autoregressive state rather than
+    replacing it (contrast with
+    :func:`pyhgf.updates.vectorized.volatile.prediction.vectorized_layer_prediction`,
+    where the parent's prediction fully determines the child's expected mean).
+
+    The two predicted precisions follow the improved (piHGF) scheme of the
+    nodalised backend, with the volatility parent's moment-generating-function
+    correction and the value parent's first-order Laplace term:
+
+    .. math::
+
+        \Omega_a^{(k)} = t^{(k)} \exp\!\left( \omega_a
+            + \sum_j \left( \kappa_{a,j} \hat{\mu}_j
+            + \frac{\kappa_{a,j}^2}{2 \tilde{\pi}_j} \right) \right), \qquad
+        \hat{\pi}_a^{(k)} = \left( \frac{1}{\pi_a^{(k-1)}} + \Omega_a^{(k)}
+            \right)^{-1},
+
+    .. math::
+
+        \frac{1}{\tilde{\pi}_a^{(k)}} = \frac{1}{\hat{\pi}_a^{(k)}}
+            + \sum_b \frac{(t^{(k)} W_{a,b} \, g'(\hat{\mu}_b))^2}{\tilde{\pi}_b},
+        \qquad
+        \gamma_a^{(k)} = \Omega_a^{(k)} \, \tilde{\pi}_a^{(k)}.
+
+    Unlike the volatile-layer kernel, the Laplace value-coupling term carries the
+    time step (the drift contribution to the mean is scaled by :math:`t^{(k)}`),
+    matching the nodalised backend exactly.
+
+    Parameters
+    ----------
+    child_state :
+        Current state of the layer being predicted.
+    params :
+        The layer's parameters; ``tonic_volatility``, ``tonic_drift`` and
+        ``autoconnection_strength`` must be set (see
+        :meth:`pyhgf.typing.vectorised.LayerParams.create_continuous`).
+    time_step :
+        Time step :math:`t^{(k)}` for the prediction.
+    value_parent_state :
+        State of the value-parent layer, or ``None`` when the layer has no value
+        parent (the drift is then :math:`\rho` alone).
+    weights :
+        Value-coupling matrix connecting this layer to its value parent, shape
+        ``(n_self, n_parent)``. Required with *value_parent_state*.
+    coupling_fn :
+        Coupling function applied elementwise to the value parent's expected
+        means. Required with *value_parent_state*.
+    volatility_parent_state :
+        State of the volatility-parent layer, or ``None`` when the layer's
+        volatility is tonic only.
+    volatility_weights :
+        Volatility-coupling matrix :math:`\kappa`, shape ``(n_self, n_parent)``.
+        Required with *volatility_parent_state*.
+    is_static_leaf :
+        If True, the layer is the clamped observation leaf *without* a volatility
+        parent: it does not undergo a Gaussian random walk between observations,
+        so both predicted precisions are held at the prior precision (the
+        nodalised backend's input-node convention). A leaf *with* a volatility
+        parent does walk, so it takes the regular path and must be passed with
+        ``is_static_leaf=False``. Distinct from
+        :attr:`~pyhgf.updates.vectorized.continuous.posterior.ValueChild.precision_is_clamped`,
+        which holds for *every* clamped leaf.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with ``expected_mean``, ``expected_precision``,
+        ``conditional_expected_precision`` and ``effective_precision`` populated.
+    """
+    assert params.tonic_drift is not None
+    assert params.tonic_volatility is not None
+    assert params.autoconnection_strength is not None
+
+    # 1. Expected mean: autoregression plus time-scaled drift.
+    driftrate = params.tonic_drift
+    if value_parent_state is not None:
+        assert weights is not None and coupling_fn is not None
+        driftrate = driftrate + jnp.matmul(
+            weights, coupling_fn(value_parent_state.expected_mean)
+        )
+    expected_mean = (
+        params.autoconnection_strength * child_state.mean + time_step * driftrate
+    )
+
+    # 2. Total volatility, with the MGF correction κ²/(2 π̃) that treats the
+    # volatility parent as a full Gaussian rather than a point estimate.
+    total_volatility = params.tonic_volatility
+    if volatility_parent_state is not None:
+        assert volatility_weights is not None
+        total_volatility = total_volatility + jnp.matmul(
+            volatility_weights, volatility_parent_state.expected_mean
+        )
+        total_volatility = total_volatility + jnp.matmul(
+            volatility_weights**2,
+            1.0 / (2.0 * volatility_parent_state.expected_precision),
+        )
+    predicted_volatility = time_step * jnp.exp(total_volatility)
+    predicted_volatility = jnp.where(
+        predicted_volatility > 1e-128, predicted_volatility, jnp.nan
+    )
+
+    # 3. Laplace value-coupling variance: Σ_b (t · W_ab · g'(μ̂_b))² / π̃_b.
+    value_coupling_variance = jnp.zeros_like(child_state.precision)
+    if value_parent_state is not None:
+        assert weights is not None and coupling_fn is not None
+        g_prime = vmap(grad(coupling_fn))(value_parent_state.expected_mean)
+        value_coupling_variance = (time_step**2) * jnp.matmul(
+            weights**2, g_prime**2 / value_parent_state.expected_precision
+        )
+
+    # 4. Conditional (π̂) and marginal (π̃) predicted precisions, effective
+    # precision γ.
+    conditional_expected_precision = 1.0 / (
+        1.0 / child_state.precision + predicted_volatility
+    )
+    expected_precision = 1.0 / (
+        1.0 / child_state.precision + predicted_volatility + value_coupling_variance
+    )
+    effective_precision = predicted_volatility * expected_precision
+
+    # 5. Static-leaf override: a clamped leaf with no volatility parent takes no
+    # random walk between observations — both predicted precisions stay at the
+    # prior (the nodalised input-node convention).
+    if is_static_leaf:
+        expected_precision = child_state.precision
+        conditional_expected_precision = child_state.precision
+
+    return dataclasses.replace(
+        child_state,
+        expected_mean=expected_mean,
+        expected_precision=expected_precision,
+        conditional_expected_precision=conditional_expected_precision,
+        effective_precision=effective_precision,
+    )

--- a/pyhgf/updates/vectorized/continuous/prediction_error.py
+++ b/pyhgf/updates/vectorized/continuous/prediction_error.py
@@ -1,0 +1,95 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Vectorized prediction errors for layers of regular continuous nodes."""
+
+import dataclasses
+
+from pyhgf.typing.vectorised import LayerState
+
+
+def vectorized_continuous_value_prediction_error(layer: LayerState) -> LayerState:
+    r"""Compute the value prediction error for all nodes in a continuous layer.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.prediction_error.continuous.continuous_node_value_prediction_error`:
+
+    .. math::
+
+        \delta_a^{(k)} = \mu_a^{(k)} - \hat{\mu}_a^{(k)}.
+
+    Parameters
+    ----------
+    layer :
+        Current layer with ``mean`` and ``expected_mean`` set.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with ``value_prediction_error`` set.
+    """
+    return dataclasses.replace(
+        layer, value_prediction_error=layer.mean - layer.expected_mean
+    )
+
+
+def vectorized_continuous_volatility_prediction_error(layer: LayerState) -> LayerState:
+    r"""Compute the volatility prediction error for all nodes in a continuous layer.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.prediction_error.continuous.continuous_node_volatility_prediction_error`:
+
+    .. math::
+
+        \Delta_a^{(k)} = \frac{\tilde{\pi}_a^{(k)}}{\pi_a^{(k)}}
+            + \tilde{\pi}_a^{(k)} \left( \delta_a^{(k)} \right)^2 - 1.
+
+    The nodalised backend divides by the number of volatility parents; the
+    vectorized layer topology allows at most one volatility parent per layer, so
+    no division is applied.
+
+    Parameters
+    ----------
+    layer :
+        Current layer with ``mean``, ``expected_mean``, ``precision`` and
+        ``expected_precision`` set.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with ``volatility_prediction_error`` set.
+    """
+    volatility_pe = (
+        (layer.expected_precision / layer.precision)
+        + layer.expected_precision * (layer.mean - layer.expected_mean) ** 2
+        - 1.0
+    )
+    return dataclasses.replace(layer, volatility_prediction_error=volatility_pe)
+
+
+def vectorized_continuous_prediction_error(
+    layer: LayerState,
+    has_volatility_parent: bool = False,
+) -> LayerState:
+    """Compute the prediction errors a continuous layer sends to its parents.
+
+    This is the vectorized equivalent of
+    :func:`pyhgf.updates.prediction_error.continuous.continuous_node_prediction_error`.
+    The value prediction error is always computed; the volatility prediction
+    error only when there is a volatility parent to consume it.
+
+    Parameters
+    ----------
+    layer :
+        Current layer with posterior ``mean`` and ``precision`` set.
+    has_volatility_parent :
+        Whether the layer has a volatility-parent layer.
+
+    Returns
+    -------
+    LayerState
+        Updated layer state with the prediction errors set.
+    """
+    layer = vectorized_continuous_value_prediction_error(layer)
+    if has_volatility_parent:
+        layer = vectorized_continuous_volatility_prediction_error(layer)
+    return layer

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -29,6 +29,13 @@ from pyhgf.updates.vectorized.categorical import (
     vectorized_categorical_prediction,
     vectorized_categorical_prediction_error,
 )
+from pyhgf.updates.vectorized.continuous import (
+    ValueChild,
+    VolatilityChild,
+    vectorized_continuous_posterior_update,
+    vectorized_continuous_prediction,
+    vectorized_continuous_prediction_error,
+)
 from pyhgf.updates.vectorized.learning import (
     vectorized_weight_gradient,
     vectorized_weight_gradient_factors,
@@ -1419,3 +1426,212 @@ def batched_prediction_states(network: Network, x: jnp.ndarray) -> tuple:
         return tuple(elem.state for elem in _prediction_sweep(network, xi).layers)
 
     return jax.vmap(one)(x)
+
+
+# ---------------------------------------------------------------------------
+# DAG networks
+# ---------------------------------------------------------------------------
+#
+# Continuous networks are DAGs rather than chains: each layer can have one
+# value-parent layer and one volatility-parent layer, recorded on the *parent*
+# as ``value_child_idx`` / ``volatility_child_idx``. The builder guarantees
+# that every parent has a higher index than its children, so the prediction
+# sweep runs top-down in descending index order and the update sweep runs
+# bottom-up in ascending order.
+
+
+def _assert_continuous_network(network: Network) -> None:
+    """Check that every element is a continuous ``Layer`` (no stacks, no mixing)."""
+    for i, elem in enumerate(network.layers):
+        if isinstance(elem, LayerStack):
+            raise NotImplementedError(
+                "Continuous networks do not support LayerStack elements yet."
+            )
+        if elem.kind != "continuous":
+            raise ValueError(
+                f"Layer {i} has kind {elem.kind!r}: continuous sweeps require "
+                "an all-continuous network."
+            )
+
+
+def _continuous_parent_maps(
+    network: Network,
+) -> tuple[list, list]:
+    """Invert the child indices into per-layer parent indices.
+
+    Returns ``(value_parent_of, volatility_parent_of)``, each one entry per layer
+    holding the parent's index or ``None``.
+    """
+    n = len(network.layers)
+    value_parent_of: list = [None] * n
+    volatility_parent_of: list = [None] * n
+    for j, elem in enumerate(network.layers):
+        if elem.value_child_idx is not None:
+            value_parent_of[elem.value_child_idx] = j
+        if elem.volatility_child_idx is not None:
+            volatility_parent_of[elem.volatility_child_idx] = j
+    return value_parent_of, volatility_parent_of
+
+
+def _continuous_prediction_sweep(
+    network: Network,
+    value_parent_of: list,
+    volatility_parent_of: list,
+    *,
+    time_step: float = 1.0,
+) -> Network:
+    """Top-down prediction sweep over a continuous network.
+
+    Predicts every layer from its value and volatility parents, in descending
+    index order so parents are always predicted before their children. Nothing
+    is clamped: observations enter in :func:`_continuous_update_sweep`. The
+    parent maps come from :func:`_continuous_parent_maps`.
+    """
+    elements = list(network.layers)
+    for i in range(len(elements) - 1, -1, -1):
+        elem = elements[i]
+        vp = value_parent_of[i]
+        vlp = volatility_parent_of[i]
+        new_state = vectorized_continuous_prediction(
+            child_state=elem.state,
+            params=elem.params,
+            time_step=time_step,
+            value_parent_state=None if vp is None else elements[vp].state,
+            weights=None if vp is None else elements[vp].weights_in,
+            coupling_fn=None if vp is None else elements[vp].coupling_fn,
+            volatility_parent_state=(None if vlp is None else elements[vlp].state),
+            volatility_weights=(
+                None if vlp is None else elements[vlp].volatility_weights_in
+            ),
+            is_static_leaf=elem.is_input_layer and vlp is None,
+        )
+        elements[i] = dataclasses.replace(elem, state=new_state)
+
+    return dataclasses.replace(network, layers=tuple(elements))
+
+
+def _continuous_update_sweep(
+    network: Network,
+    y: jnp.ndarray,
+    value_parent_of: list,
+    *,
+    time_step: float = 1.0,
+) -> Network:
+    """Bottom-up prediction-error and posterior-update sweep.
+
+    Clamps the observations on layer 0, computes its prediction errors, then
+    walks the layers in ascending order: each layer's posterior integrates the
+    prediction errors of its value and volatility children (already computed,
+    since children carry lower indices), and its own prediction errors are then
+    written for the parents above. ``value_parent_of`` comes from
+    :func:`_continuous_parent_maps`; the volatility side is read off each
+    layer's ``has_volatility_parent``.
+    """
+    elements = list(network.layers)
+
+    # Clamp the observations and compute the leaf prediction errors.
+    leaf_state = dataclasses.replace(elements[0].state, mean=y)
+    leaf_state = vectorized_continuous_prediction_error(
+        leaf_state, has_volatility_parent=elements[0].has_volatility_parent
+    )
+    elements[0] = dataclasses.replace(elements[0], state=leaf_state)
+
+    for i in range(1, len(elements)):
+        elem = elements[i]
+
+        value_child = None
+        if elem.value_child_idx is not None:
+            child_elem = elements[elem.value_child_idx]
+            value_child = ValueChild(
+                state=child_elem.state,
+                weights=elem.weights_in,
+                coupling_fn=elem.coupling_fn,
+                # Only layer 0 is clamped, and the update loop below skips it,
+                # so its posterior precision is the one that never moves.
+                precision_is_clamped=child_elem.is_input_layer,
+            )
+
+        volatility_child = None
+        if elem.volatility_child_idx is not None:
+            child_elem = elements[elem.volatility_child_idx]
+            volatility_child = VolatilityChild(
+                state=child_elem.state,
+                kappa=elem.volatility_weights_in,
+                params=child_elem.params,
+            )
+
+        if value_child is None and volatility_child is None:
+            # A layer nobody names as parent receives no message; nothing to do.
+            continue
+
+        new_state = vectorized_continuous_posterior_update(
+            elem.state,
+            value_child=value_child,
+            volatility_child=volatility_child,
+            volatility_updates=network.volatility_updates,
+            time_step=time_step,
+            max_posterior_precision=network.max_posterior_precision,
+        )
+
+        # Prediction errors are only needed when a parent above will read them.
+        if value_parent_of[i] is not None or elem.has_volatility_parent:
+            new_state = vectorized_continuous_prediction_error(
+                new_state, has_volatility_parent=elem.has_volatility_parent
+            )
+
+        elements[i] = dataclasses.replace(elem, state=new_state)
+
+    return dataclasses.replace(network, layers=tuple(elements))
+
+
+@eqx.filter_jit
+def run_continuous_scan(
+    network: Network,
+    ys: jnp.ndarray,
+    time_steps: jnp.ndarray,
+    record: tuple = (),
+) -> tuple:
+    """Filter a sequence of observations through a continuous network.
+
+    Runs ``jax.lax.scan`` over (prediction sweep, update sweep) pairs. There
+    is no weight learning: the coupling matrices are parameters of the filter.
+
+    Parameters
+    ----------
+    network :
+        The initial continuous network state.
+    ys :
+        Observations clamped on layer 0 at each step, shape ``(T, n_obs)``.
+    time_steps :
+        Per-step time steps, shape ``(T,)``.
+    record :
+        Tuple of ``LayerState`` field names to record at every step. With an
+        empty tuple (default) the per-step output is layer 0's ``expected_mean``
+        alone; otherwise it is ``(traj_step, prediction)``.
+
+    Returns
+    -------
+    ``(final_network, step_output)`` with per-step outputs stacked along a
+    leading ``(T,)`` axis.
+    """
+    # The topology is static, so validate and invert it once rather than once
+    # per sweep inside the scan body.
+    _assert_continuous_network(network)
+    value_parent_of, volatility_parent_of = _continuous_parent_maps(network)
+
+    def body(net, xs):
+        y, dt = xs
+        predicted = _continuous_prediction_sweep(
+            net, value_parent_of, volatility_parent_of, time_step=dt
+        )
+        updated = _continuous_update_sweep(predicted, y, value_parent_of, time_step=dt)
+        prediction = updated.layers[0].state.expected_mean
+        if record:
+            traj_step = {
+                field: tuple(getattr(elem.state, field) for elem in updated.layers)
+                for field in record
+            }
+            return updated, (traj_step, prediction)
+        return updated, prediction
+
+    return jax.lax.scan(body, network, (ys, time_steps))

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -396,8 +396,6 @@ def test_three_backends_binary_volatile():
         dn = (
             DeepNetwork(
                 volatility_updates=volatility_updates,
-                # The nodalised backends always propagate value-parent
-                # uncertainty, so the vectorised one has to be asked to.
                 feedforward_uncertainty=True,
             )
             .add_layer(size=n_targets, kind="binary")
@@ -1259,9 +1257,6 @@ def test_input_layer_precision_equilibrates_instead_of_running_away():
     volatility prediction error can never be positive, so a layer that did update it
     would drive its own diffusion to zero and then accumulate evidence forever. Held
     at the tonic value, the diffusion bounds the precision.
-
-    At the default, where value parents propagate nothing, it settles near 7.11; with
-    ``feedforward_uncertainty=True`` it settles lower, near 4.45, and sooner.
     """
     x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
     net = _three_layer(True)

--- a/tests/test_eqx_types.py
+++ b/tests/test_eqx_types.py
@@ -61,12 +61,27 @@ def test_layer_state_create_defaults():
 
 
 def test_layer_params_create_defaults():
-    """LayerParams.create matches the legacy class's defaults."""
+    """LayerParams.create matches the legacy class's defaults.
+
+    Parameter fields are kind-specific: the volatile constructor allocates the
+    internal-volatility field only, the continuous constructor the other three.
+    """
     n = 4
     p = LayerParams.create(n)
     assert jnp.all(p.tonic_volatility_vol == -4.0)
-    for fname in LayerParams.__dataclass_fields__:
-        assert getattr(p, fname).shape == (n,), fname
+    assert p.tonic_volatility_vol.shape == (n,)
+    for fname in ("tonic_volatility", "tonic_drift", "autoconnection_strength"):
+        assert getattr(p, fname) is None, fname
+
+    c = LayerParams.create_continuous(n)
+    assert c.tonic_volatility_vol is None
+    for fname, value in (
+        ("tonic_volatility", -4.0),
+        ("tonic_drift", 0.0),
+        ("autoconnection_strength", 1.0),
+    ):
+        assert jnp.all(getattr(c, fname) == value), fname
+        assert getattr(c, fname).shape == (n,), fname
 
 
 def test_layer_state_is_pytree():

--- a/tests/test_vectorized_continuous.py
+++ b/tests/test_vectorized_continuous.py
@@ -1,0 +1,412 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+"""Parity tests: vectorized continuous layers vs.
+
+the nodalised backend. Every test builds the same topology twice — once with the
+nodalised :class:`pyhgf.model.Network`, once with the vectorized
+:class:`pyhgf.model.DeepNetwork` continuous layers — runs the same observations through
+both, and compares the per-node trajectories.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from pyhgf.model import Network
+from pyhgf.model.deep_network import DeepNetwork
+
+U = jnp.array([0.2, 0.5, -0.3, 1.0, 0.1, -0.7, 0.4])
+FIELDS = ("mean", "precision", "expected_mean", "expected_precision")
+
+
+def assert_parity(nod: Network, vec: DeepNetwork, node_to_layer: dict):
+    """Compare nodalised node trajectories against vectorized layer trajectories.
+
+    ``node_to_layer`` maps a nodalised node index to ``(layer_idx, node_idx)`` in the
+    vectorized network.
+    """
+    for node, (layer, pos) in node_to_layer.items():
+        for field in FIELDS:
+            a = nod.node_trajectories[node][field]
+            b = vec.trajectories[field][layer][:, pos]
+            assert jnp.allclose(a, b, rtol=1e-5, atol=1e-6), (
+                f"node {node} / layer {layer}[{pos}] diverge on {field}: {a} vs {b}"
+            )
+
+
+def test_two_level_chain():
+    """Observation node with one value parent (the one-node HGF)."""
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0)})
+
+
+@pytest.mark.parametrize("volatility_updates", ["standard", "eHGF", "unbounded"])
+def test_volatility_children_leaf(volatility_updates):
+    """Leaf with both a value parent and a volatility parent (two-node HGF)."""
+    nod = (
+        Network(volatility_updates=volatility_updates)
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .add_nodes(volatility_children=0)
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates=volatility_updates)
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(
+            1,
+            kind="continuous",
+            volatility_children=0,
+            volatility_fully_connected=(volatility_updates != "unbounded"),
+        )
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+@pytest.mark.parametrize("volatility_updates", ["standard", "eHGF", "unbounded"])
+def test_classic_three_level(volatility_updates):
+    """The classic 3-level continuous HGF: x2 is the volatility parent of x1."""
+    nod = (
+        Network(volatility_updates=volatility_updates)
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .add_nodes(volatility_children=1)
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates=volatility_updates)
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(
+            1,
+            kind="continuous",
+            volatility_children=1,
+            volatility_fully_connected=(volatility_updates != "unbounded"),
+        )
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+@pytest.mark.parametrize("volatility_updates", ["standard", "eHGF"])
+def test_fully_connected_layers(volatility_updates):
+    """Width-2 layers with dense value coupling and a dense volatility parent.
+
+    Nodalised equivalent: two leaf nodes, two value parents each coupled to
+    both leaves, and one volatility parent modulating both value parents.
+    """
+    nod = (
+        Network(volatility_updates=volatility_updates)
+        .add_nodes(n_nodes=2)
+        .add_nodes(n_nodes=2, value_children=([0, 1], [0.5, 0.5]))
+        .add_nodes(volatility_children=[2, 3])
+        .input_data(input_data=jnp.stack([U, U * 0.5 + 0.1], axis=1))
+    )
+    vec = (
+        DeepNetwork(volatility_updates=volatility_updates)
+        .add_layer(2, kind="continuous")
+        .add_layer(2, kind="continuous")
+        .add_layer(1, kind="continuous", volatility_children=1)
+        .input_data(jnp.stack([U, U * 0.5 + 0.1], axis=1), record=FIELDS)
+    )
+    assert_parity(
+        nod,
+        vec,
+        {0: (0, 0), 1: (0, 1), 2: (1, 0), 3: (1, 1), 4: (2, 0)},
+    )
+
+
+def test_unbounded_one_to_one_multi_node():
+    """Width-2 one-to-one volatility coupling under the unbounded update."""
+    nod = (
+        Network(volatility_updates="unbounded")
+        .add_nodes(n_nodes=2)
+        .add_nodes(n_nodes=2, value_children=([0, 1], [0.5, 0.5]))
+        .add_nodes(volatility_children=2)
+        .add_nodes(volatility_children=3)
+        .input_data(input_data=jnp.stack([U, U * 0.5 + 0.1], axis=1))
+    )
+    vec = (
+        DeepNetwork(volatility_updates="unbounded")
+        .add_layer(2, kind="continuous")
+        .add_layer(2, kind="continuous")
+        .add_layer(
+            2,
+            kind="continuous",
+            volatility_children=1,
+            volatility_fully_connected=False,
+        )
+        .input_data(jnp.stack([U, U * 0.5 + 0.1], axis=1), record=FIELDS)
+    )
+    assert_parity(
+        nod,
+        vec,
+        {0: (0, 0), 1: (0, 1), 2: (1, 0), 3: (1, 1), 4: (2, 0), 5: (2, 1)},
+    )
+
+
+@pytest.mark.parametrize("volatility_updates", ["standard", "eHGF"])
+def test_dual_role_parent(volatility_updates):
+    """A layer that is a value parent of one layer and volatility parent of another."""
+    nod = (
+        Network(volatility_updates=volatility_updates)
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .add_nodes(value_children=1, volatility_children=0)
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates=volatility_updates)
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(
+            1,
+            kind="continuous",
+            value_children=1,
+            volatility_children=0,
+        )
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+@pytest.mark.parametrize("volatility_updates", ["standard", "eHGF"])
+def test_nonlinear_coupling(volatility_updates):
+    """A sinusoidal coupling function on the value edge."""
+    nod = (
+        Network(volatility_updates=volatility_updates)
+        .add_nodes()
+        .add_nodes(value_children=0, coupling_fn=(jnp.sin,))
+        .add_nodes(volatility_children=0)
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates=volatility_updates)
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous", coupling_fn=jnp.sin)
+        .add_layer(1, kind="continuous", volatility_children=0)
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+def test_irregular_time_steps():
+    """Non-uniform inter-observation intervals."""
+    time_steps = jnp.array([1.0, 0.5, 2.0, 1.5, 1.0, 3.0, 0.1])
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .add_nodes(volatility_children=1)
+        .input_data(input_data=U, time_steps=time_steps)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous", volatility_children=1)
+        .input_data(U, time_steps=time_steps, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+def test_parameter_overrides():
+    """Per-layer parameter overrides reach the filter."""
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(
+            value_children=0,
+            node_parameters={
+                "tonic_volatility": -2.0,
+                "tonic_drift": 0.1,
+                "autoconnection_strength": 0.9,
+            },
+        )
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(
+            1,
+            kind="continuous",
+            tonic_volatility=-2.0,
+            tonic_drift=0.1,
+            autoconnection_strength=0.9,
+        )
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0)})
+
+
+def test_builder_validation():
+    """Topology and API constraints raise clear errors."""
+    # continuous cannot mix with volatile
+    with pytest.raises(ValueError, match="cannot mix"):
+        DeepNetwork().add_layer(2).add_layer(2, kind="continuous")
+    with pytest.raises(ValueError, match="cannot mix"):
+        DeepNetwork().add_layer(2, kind="continuous").add_layer(2)
+
+    # no bias column on continuous layers
+    with pytest.raises(ValueError, match="tonic_drift"):
+        DeepNetwork().add_layer(2, kind="continuous", add_constant_input=True)
+
+    # every continuous-only argument is rejected on other kinds rather than
+    # silently ignored
+    for kwargs in (
+        {"value_children": 0},
+        {"volatility_children": 0},
+        {"value_coupling": 0.5},
+        {"volatility_coupling": 0.5},
+        {"volatility_fully_connected": False},
+    ):
+        with pytest.raises(ValueError, match="only valid for continuous layers"):
+            DeepNetwork().add_layer(2).add_layer(2, **kwargs)
+
+    # a child can have at most one parent of each type
+    with pytest.raises(ValueError, match="already has a value parent"):
+        (
+            DeepNetwork()
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous", value_children=0)
+        )
+
+    # unbounded requires one-to-one volatility coupling
+    with pytest.raises(ValueError, match="one-to-one"):
+        (
+            DeepNetwork(volatility_updates="unbounded")
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous", volatility_children=1)
+        )
+
+    # kind-specific parameter overrides
+    with pytest.raises(ValueError, match="do not apply"):
+        DeepNetwork().add_layer(2, tonic_drift=0.1)
+    with pytest.raises(ValueError, match="do not apply"):
+        DeepNetwork().add_layer(2, kind="continuous", tonic_volatility_vol=-2.0)
+
+    # deep-network entry points are rejected on continuous networks
+    import optax
+
+    net = DeepNetwork().add_layer(2, kind="continuous").add_layer(2, kind="continuous")
+    with pytest.raises(ValueError, match="input_data"):
+        net.fit(jnp.zeros((3, 2)), jnp.zeros((3, 2)), optimizer=optax.sgd(0.1))
+    with pytest.raises(ValueError, match="input_data"):
+        net.predict(jnp.zeros((3, 2)))
+
+    # and input_data is rejected on volatile networks
+    with pytest.raises(ValueError, match="continuous"):
+        DeepNetwork().add_layer(2).add_layer(2).input_data(jnp.zeros((3, 2)))
+
+
+def test_record_field_validation():
+    """``record`` only accepts fields the network actually allocates."""
+    net = DeepNetwork().add_layer(1, kind="continuous").add_layer(1, kind="continuous")
+
+    # Continuous layers leave the internal-volatility fields at ``None``, so
+    # recording them would silently yield nothing.
+    with pytest.raises(ValueError, match="Unknown record field"):
+        net.input_data(U, record=("mean_vol",))
+    with pytest.raises(ValueError, match="Unknown record field"):
+        net.input_data(U, record=("not_a_field",))
+
+    # ``volatility_prediction_error`` is allocated only where a volatility
+    # parent exists, so it is recordable on that topology and not otherwise.
+    with pytest.raises(ValueError, match="Unknown record field"):
+        net.input_data(U, record=("volatility_prediction_error",))
+
+    with_vol = (
+        DeepNetwork()
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous", volatility_children=1)
+        .input_data(U, record=("volatility_prediction_error",))
+    )
+    assert with_vol.trajectories["volatility_prediction_error"][1].shape == (len(U), 1)
+
+
+def test_volatility_coupling_strength():
+    """An explicit coupling strength reaches the filter (fan-in 1: no scaling)."""
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(value_children=0)
+        .add_nodes(volatility_children=([0], [0.7]))
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(
+            1,
+            kind="continuous",
+            volatility_children=0,
+            volatility_coupling=0.7,
+        )
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0), 2: (2, 0)})
+
+
+def test_coupling_fan_in_normalisation():
+    """Dense W and κ entries are strength / n_parents; one-to-one keeps the strength."""
+    dense = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(2, kind="continuous")
+        .add_layer(2, kind="continuous", value_coupling=0.6)
+        .add_layer(4, kind="continuous", volatility_children=1, volatility_coupling=0.8)
+    )
+    weights = dense.state.layers[1].weights_in
+    assert weights.shape == (2, 2)
+    assert jnp.allclose(weights, 0.6 / 2)
+    kappa = dense.state.layers[2].volatility_weights_in
+    assert kappa.shape == (2, 4)
+    assert jnp.allclose(kappa, 0.8 / 4)
+
+    one_to_one = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(2, kind="continuous")
+        .add_layer(2, kind="continuous")
+        .add_layer(
+            2,
+            kind="continuous",
+            volatility_children=1,
+            volatility_coupling=0.8,
+            volatility_fully_connected=False,
+        )
+    )
+    kappa = one_to_one.state.layers[2].volatility_weights_in
+    assert jnp.allclose(kappa, 0.8 * jnp.eye(2))
+
+
+def test_value_coupling_strength():
+    """An explicit value coupling strength reaches the filter (fan-in 1)."""
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(value_children=([0], [0.7]))
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous", value_coupling=0.7)
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0)})

--- a/tests/test_vectorized_continuous.py
+++ b/tests/test_vectorized_continuous.py
@@ -6,16 +6,36 @@ the nodalised backend. Every test builds the same topology twice — once with t
 nodalised :class:`pyhgf.model.Network`, once with the vectorized
 :class:`pyhgf.model.DeepNetwork` continuous layers — runs the same observations through
 both, and compares the per-node trajectories.
+
+The tests at the bottom of the file exercise the update kernels and the sweep guards
+directly, for the paths the builder cannot reach on its own.
 """
+
+import dataclasses
 
 import jax.numpy as jnp
 import pytest
 
 from pyhgf.model import Network
 from pyhgf.model.deep_network import DeepNetwork
+from pyhgf.typing.vectorised import LayerParams, LayerStack, LayerState
+from pyhgf.updates.vectorized.continuous import (
+    ValueChild,
+    VolatilityChild,
+    vectorized_continuous_posterior_update,
+    vectorized_continuous_posterior_update_ehgf,
+    vectorized_continuous_posterior_update_standard,
+)
+from pyhgf.utils.vectorized_belief_propagation import run_continuous_scan
 
 U = jnp.array([0.2, 0.5, -0.3, 1.0, 0.1, -0.7, 0.4])
 FIELDS = ("mean", "precision", "expected_mean", "expected_precision")
+
+
+def _state(**fields) -> LayerState:
+    """Build a one-node continuous ``LayerState``, overriding the named fields."""
+    base = LayerState.create_continuous(1, has_volatility_parent=True)
+    return dataclasses.replace(base, **{k: jnp.array([v]) for k, v in fields.items()})
 
 
 def assert_parity(nod: Network, vec: DeepNetwork, node_to_layer: dict):
@@ -276,6 +296,14 @@ def test_builder_validation():
         with pytest.raises(ValueError, match="only valid for continuous layers"):
             DeepNetwork().add_layer(2).add_layer(2, **kwargs)
 
+    # child indices must name an existing layer
+    with pytest.raises(IndexError, match="does not name an existing layer"):
+        (
+            DeepNetwork()
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous", volatility_children=5)
+        )
+
     # a child can have at most one parent of each type
     with pytest.raises(ValueError, match="already has a value parent"):
         (
@@ -283,6 +311,26 @@ def test_builder_validation():
             .add_layer(2, kind="continuous")
             .add_layer(2, kind="continuous")
             .add_layer(2, kind="continuous", value_children=0)
+        )
+    with pytest.raises(ValueError, match="already has a volatility parent"):
+        (
+            DeepNetwork(volatility_updates="standard")
+            .add_layer(2, kind="continuous")
+            .add_layer(2, kind="continuous", volatility_children=0)
+            .add_layer(2, kind="continuous", volatility_children=0)
+        )
+
+    # a one-to-one κ needs matching widths
+    with pytest.raises(ValueError, match="requires equal sizes"):
+        (
+            DeepNetwork()
+            .add_layer(2, kind="continuous")
+            .add_layer(
+                3,
+                kind="continuous",
+                volatility_children=0,
+                volatility_fully_connected=False,
+            )
         )
 
     # unbounded requires one-to-one volatility coupling
@@ -292,6 +340,21 @@ def test_builder_validation():
             .add_layer(2, kind="continuous")
             .add_layer(2, kind="continuous")
             .add_layer(2, kind="continuous", volatility_children=1)
+        )
+
+    # ...and rejects a parent that is both a value and a volatility parent
+    with pytest.raises(ValueError, match="cannot also be a value parent"):
+        (
+            DeepNetwork(volatility_updates="unbounded")
+            .add_layer(1, kind="continuous")
+            .add_layer(1, kind="continuous")
+            .add_layer(
+                1,
+                kind="continuous",
+                value_children=1,
+                volatility_children=0,
+                volatility_fully_connected=False,
+            )
         )
 
     # kind-specific parameter overrides
@@ -312,6 +375,13 @@ def test_builder_validation():
     # and input_data is rejected on volatile networks
     with pytest.raises(ValueError, match="continuous"):
         DeepNetwork().add_layer(2).add_layer(2).input_data(jnp.zeros((3, 2)))
+
+    # observations must be as wide as layer 0
+    continuous = (
+        DeepNetwork().add_layer(2, kind="continuous").add_layer(2, kind="continuous")
+    )
+    with pytest.raises(ValueError, match="but layer 0 has"):
+        continuous.input_data(jnp.zeros((3, 5)))
 
 
 def test_record_field_validation():
@@ -410,3 +480,172 @@ def test_value_coupling_strength():
         .input_data(U, record=FIELDS)
     )
     assert_parity(nod, vec, {0: (0, 0), 1: (1, 0)})
+
+
+def test_state_overrides():
+    """Per-layer state overrides reach the filter."""
+    nod = (
+        Network(volatility_updates="standard")
+        .add_nodes()
+        .add_nodes(
+            value_children=0,
+            node_parameters={"mean": 0.5, "precision": 2.0},
+        )
+        .input_data(input_data=U)
+    )
+    vec = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous", mean=0.5, precision=2.0)
+        .input_data(U, record=FIELDS)
+    )
+    assert_parity(nod, vec, {0: (0, 0), 1: (1, 0)})
+
+
+def test_input_data_without_record():
+    """Without ``record`` only the one-step-ahead predictions are kept."""
+
+    def build():
+        return (
+            DeepNetwork(volatility_updates="standard")
+            .add_layer(1, kind="continuous")
+            .add_layer(1, kind="continuous")
+        )
+
+    plain = build().input_data(U)
+    assert plain.trajectories is None
+    assert plain.predictions.shape == (len(U), 1)
+
+    # Recording changes what is reported, never what is filtered.
+    recorded = build().input_data(U, record=FIELDS)
+    assert jnp.allclose(plain.predictions, recorded.predictions)
+    assert jnp.allclose(plain.predictions, recorded.trajectories["expected_mean"][0])
+
+
+def test_continuous_sweeps_reject_other_networks():
+    """The continuous scan refuses networks it cannot interpret."""
+    volatile = DeepNetwork().add_layer(2).add_layer(2)
+    with pytest.raises(ValueError, match="all-continuous network"):
+        run_continuous_scan(volatile.state, jnp.zeros((3, 2)), jnp.ones(3))
+
+    # Continuous layers cannot be stacked and cannot mix with volatile ones, so
+    # the only way to present a LayerStack to the sweep is to splice one in.
+    stacked = (
+        DeepNetwork()
+        .add_layer(size=4)
+        .add_layer_stack(layer_sizes=[4] * 5)
+        .add_layer(size=2)
+    )
+    stack = next(e for e in stacked.state.layers if isinstance(e, LayerStack))
+    continuous = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+    )
+    spliced = dataclasses.replace(continuous.state, layers=(stack,))
+    with pytest.raises(NotImplementedError, match="LayerStack"):
+        run_continuous_scan(spliced, jnp.zeros((3, 4)), jnp.ones(3))
+
+
+def test_layer_without_children_is_skipped():
+    """A layer nobody names as parent receives no message and stays at its prior."""
+    net = (
+        DeepNetwork(volatility_updates="standard")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+        .add_layer(1, kind="continuous")
+    )
+    # Detach the top layer: the builder's chain default always gives a layer a
+    # child, so this topology can only be reached by editing the PyTree.
+    elements = list(net.state.layers)
+    elements[2] = dataclasses.replace(
+        elements[2], value_child_idx=None, volatility_child_idx=None
+    )
+    net.state = dataclasses.replace(net.state, layers=tuple(elements))
+    detached = net.state.layers[2].state
+
+    net.input_data(U, record=("mean", "precision"))
+
+    assert jnp.allclose(net.trajectories["mean"][2], detached.mean)
+    assert jnp.allclose(net.trajectories["precision"][2], detached.precision)
+    # The two layers that are still connected keep filtering.
+    assert not jnp.allclose(net.trajectories["mean"][1], detached.mean)
+
+
+def _value_child() -> ValueChild:
+    """Build a one-node value child with a linear coupling."""
+    return ValueChild(
+        state=_state(
+            precision=3.0,
+            expected_precision=2.0,
+            conditional_expected_precision=2.5,
+            value_prediction_error=0.4,
+        ),
+        weights=jnp.array([[0.8]]),
+        coupling_fn=lambda x: x,
+        precision_is_clamped=False,
+    )
+
+
+def _volatility_child() -> VolatilityChild:
+    """Build a one-node volatility child."""
+    return VolatilityChild(
+        state=_state(
+            mean=0.2,
+            precision=2.0,
+            expected_mean=0.1,
+            expected_precision=1.6,
+            conditional_expected_precision=1.8,
+            effective_precision=0.3,
+            volatility_prediction_error=0.5,
+        ),
+        kappa=jnp.array([[1.0]]),
+        params=LayerParams.create_continuous(1),
+    )
+
+
+def test_ehgf_with_a_value_child_only():
+    """EHGF differs from the standard scheme only in the mean's denominator.
+
+    The dispatcher never routes a layer without a volatility child to the eHGF update,
+    so this exercises the kernel directly.
+    """
+    parent = _state(mean=0.3, precision=1.5, expected_mean=0.25, expected_precision=1.2)
+    child = _value_child()
+
+    standard = vectorized_continuous_posterior_update_standard(
+        parent, value_child=child
+    )
+    ehgf = vectorized_continuous_posterior_update_ehgf(parent, value_child=child)
+
+    # A linear coupling has g'' = 0, so the precision increment does not depend
+    # on where the derivatives are evaluated and the two schemes agree.
+    assert jnp.allclose(standard.precision, ehgf.precision)
+
+    # The mean shift shares a numerator: the standard scheme divides it by the
+    # posterior precision, eHGF by the predicted one.
+    assert not jnp.allclose(standard.mean, ehgf.mean)
+    assert jnp.allclose(
+        (ehgf.mean - parent.expected_mean) * parent.expected_precision,
+        (standard.mean - parent.expected_mean) * standard.precision,
+    )
+
+
+def test_posterior_dispatch_errors():
+    """The dispatcher rejects an unusable scheme rather than dropping an edge."""
+    parent = _state(mean=0.3, precision=1.5, expected_mean=0.25, expected_precision=1.2)
+
+    with pytest.raises(ValueError, match="pure volatility parents"):
+        vectorized_continuous_posterior_update(
+            parent,
+            value_child=_value_child(),
+            volatility_child=_volatility_child(),
+            volatility_updates="unbounded",
+        )
+
+    with pytest.raises(ValueError, match="Invalid volatility_updates"):
+        vectorized_continuous_posterior_update(
+            parent,
+            volatility_child=_volatility_child(),
+            volatility_updates="nonsense",
+        )


### PR DESCRIPTION
Adds `kind="continuous"` layers to the vectorised backend: regular continuous state nodes under the standard HGF drift semantics, with the value and volatility parents generalised to fully connected layers. The new `pyhgf.updates.vectorized.continuous` package mirrors the node-wise `pyhgf.updates.prediction.continuous`, `pyhgf.updates.prediction_error.continuous` and `pyhgf.updates.posterior.continuous`, including the eHGF and unbounded posterior variants.

- Continuous layers form a DAG rather than a chain. `add_layer` takes `value_children` and `volatility_children`; when neither is given, the chain default applies, and `_resolve_continuous_children` validates what is given.

- `tonic_drift` and `autoconnection_strength` are continuous-only `LayerParams` fields. A parameter override that the layer's kind would silently ignore now raises, in either direction.

- Continuous layers cannot mix with the volatile, binary and categorical kinds in one network: the semantics of an update differ, and so does the entry point. They are filtered with `input_data` rather than `fit`.

- `add_constant_input=True` is rejected on a continuous layer, whose per-node `tonic_drift` already provides the constant offset.
