### PR TITLE
Add the `synaptic_uncertainty` weight-belief learning rule

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -381,8 +381,9 @@ Vectorized learning
 .. autosummary::
    :toctree: generated/pyhgf.updates.vectorized.learning
 
-    vectorized_weight_gradient
-    vectorized_weight_gradient_factors
+    learning_weights_vectorized
+    resolve_synaptic_uncertainty_settings
+    vectorized_synaptic_uncertainty_update
 
 Model
 *****

--- a/pyhgf/model/deep_network.py
+++ b/pyhgf/model/deep_network.py
@@ -32,10 +32,11 @@ from pyhgf.typing.vectorised import (
     stack_layers,
 )
 from pyhgf.updates.vectorized.learning import (
-    vectorized_weight_gradient_factors,
+    SynapticUncertaintySettings,
+    resolve_synaptic_uncertainty_settings,
 )
 from pyhgf.utils.vectorized_belief_propagation import (
-    _weight_gradients,
+    _weight_quantities,
     batch_step,
     batched_prediction_pass,
     batched_prediction_states,
@@ -503,7 +504,7 @@ class DeepNetwork:
             construction (see *volatility_coupling*) and never learned.
         value_coupling :
             Continuous layers only — base value coupling strength (defaults to
-            ``1.0``). Dense ``weights_in`` entries are ``value_coupling /
+            ``1.0``). Dense ``weights_mean`` entries are ``value_coupling /
             n_parents``, so the drift a child receives is ``value_coupling``
             times the *average* of :math:`g(\hat{\mu})` over the parent layer,
             invariant to the parent layer's width; one-to-one edges keep
@@ -875,23 +876,23 @@ class DeepNetwork:
                     param_kwargs[k] = v
             params = LayerParams.create(n_nodes=size, **param_kwargs)
 
-            # `weights_in` lives on the parent (this Layer); layer 0 has none.
+            # `weights_mean` lives on the parent (this Layer); layer 0 has none.
             if i > 0:
                 prev_size = self.layer_sizes[i - 1]
                 n_parent_cols = size + (1 if self.add_constant_inputs[i] else 0)
                 if self.fully_connected[i]:
-                    weights_in = jnp.ones((prev_size, n_parent_cols))
+                    weights_mean = jnp.ones((prev_size, n_parent_cols))
                 else:
-                    weights_in = jnp.eye(prev_size, n_parent_cols)
+                    weights_mean = jnp.eye(prev_size, n_parent_cols)
             else:
-                weights_in = None
+                weights_mean = None
 
             coupling_fn = self.coupling_fns[i]
             layers.append(
                 Layer(
                     state=state,
                     params=params,
-                    weights_in=weights_in,
+                    weights_mean=weights_mean,
                     coupling_fn=coupling_fn,
                     add_constant_input=self.add_constant_inputs[i],
                     has_volatility_parent=self.volatility_parents[i],
@@ -1001,14 +1002,14 @@ class DeepNetwork:
             params = LayerParams.create_continuous(n_nodes=size, **param_kwargs)
 
             value_child = self.value_children[i]
-            weights_in = self._fan_in_matrix(
+            weights_mean = self._fan_in_matrix(
                 child=value_child,
                 size=size,
                 strength=self.value_couplings[i],
                 dense=self.fully_connected[i],
             )
             volatility_child = self.volatility_children[i]
-            volatility_weights_in = self._fan_in_matrix(
+            volatility_weights = self._fan_in_matrix(
                 child=volatility_child,
                 size=size,
                 strength=self.volatility_couplings[i],
@@ -1019,7 +1020,7 @@ class DeepNetwork:
                 Layer(
                     state=state,
                     params=params,
-                    weights_in=weights_in,
+                    weights_mean=weights_mean,
                     coupling_fn=self.coupling_fns[i],
                     add_constant_input=False,
                     has_volatility_parent=has_vol_parent[i],
@@ -1028,7 +1029,7 @@ class DeepNetwork:
                     kind="continuous",
                     value_child_idx=value_child,
                     volatility_child_idx=volatility_child,
-                    volatility_weights_in=volatility_weights_in,
+                    volatility_weights=volatility_weights,
                 )
             )
 
@@ -1041,6 +1042,75 @@ class DeepNetwork:
             predict_precision=self.predict_precision,
             feedforward_uncertainty=self.feedforward_uncertainty,
         )
+
+    def install_weight_belief(
+        self, layers: Optional[Sequence[int]] = None
+    ) -> "DeepNetwork":
+        """Give every weight a belief, leaving any already installed untouched.
+
+        The mean of each weight's belief is the weight itself; this adds the
+        second parameter, the accumulated precision above the prior, as an
+        array of zeros beside it (see
+        :attr:`pyhgf.typing.vectorised.Layer.weights_precision_delta`). Zero
+        precision_delta is the prior belief, so a network trained from a fresh install
+        starts exactly where plain descent at the prior variance starts.
+
+        ``learning_kind="synaptic_uncertainty"`` calls this itself, so it is
+        only needed to install a belief ahead of time, or on part of a network.
+
+        Parameters
+        ----------
+        layers :
+            Which elements receive one, as indices into ``state.layers`` where
+            ``0`` is the bottom layer. ``None`` (default) covers every element
+            holding a weight matrix. The bottom layer holds none, so naming it
+            raises.
+
+        Returns
+        -------
+        DeepNetwork
+            ``self``, with the beliefs installed.
+
+        Raises
+        ------
+        ValueError
+            If the network has no layers yet, or a named element holds no
+            weight matrix.
+        """
+        if self.state is None:
+            raise ValueError(
+                "Network has no layers yet. Call add_layer(...) before "
+                "install_weight_belief()."
+            )
+        selected = None if layers is None else {int(i) for i in layers}
+        if selected is not None:
+            holding = {
+                i
+                for i, elem in enumerate(self.state.layers)
+                if elem.weights_mean is not None
+            }
+            unheld = sorted(selected - holding)
+            if unheld:
+                raise ValueError(
+                    f"layers {unheld} hold no weight matrix, so they cannot carry "
+                    f"a weight belief. Layers holding one: {sorted(holding)}."
+                )
+        elements = []
+        for index, elem in enumerate(self.state.layers):
+            if (
+                elem.weights_mean is None
+                or elem.weights_precision_delta is not None
+                or (selected is not None and index not in selected)
+            ):
+                elements.append(elem)
+                continue
+            elements.append(
+                dataclasses.replace(
+                    elem, weights_precision_delta=jnp.zeros_like(elem.weights_mean)
+                )
+            )
+        self.state = dataclasses.replace(self.state, layers=tuple(elements))
+        return self
 
     def _ensure_optimizer_state(
         self, optimizer: Optional[optax.GradientTransformation]
@@ -1133,15 +1203,15 @@ class DeepNetwork:
 
         new_elements = list(self.state.layers)
         for i, elem in enumerate(new_elements):
-            if elem.weights_in is None:
+            if elem.weights_mean is None:
                 continue
             if isinstance(elem, LayerStack):
-                # Stack has weights_in shape (N, n_child, n_parent[+1]). Use
+                # Stack has weights_mean shape (N, n_child, n_parent[+1]). Use
                 # the same seed for every slice — matches the unrolled init's
                 # "same seed across all layers" semantics (necessary for
                 # byte-parity with the unrolled path; the underlying "all
                 # layers identical at init" pattern is a separate concern).
-                n_slices, n_children, n_parents = elem.weights_in.shape
+                n_slices, n_children, n_parents = elem.weights_mean.shape
                 per_slice = _init_matrix(
                     init_fn,
                     n_children,
@@ -1154,7 +1224,7 @@ class DeepNetwork:
                     per_slice, (n_slices, n_children, n_parents)
                 )
             else:
-                n_children, n_parents = elem.weights_in.shape
+                n_children, n_parents = elem.weights_mean.shape
                 new_weights = _init_matrix(
                     init_fn,
                     n_children,
@@ -1163,10 +1233,51 @@ class DeepNetwork:
                     seed,
                     kwargs,
                 )
-            new_elements[i] = dataclasses.replace(elem, weights_in=new_weights)
+            new_elements[i] = dataclasses.replace(elem, weights_mean=new_weights)
 
         self.state = dataclasses.replace(self.state, layers=tuple(new_elements))
         return self
+
+    def _resolve_learning(
+        self, learning_kind: str, learning_kwargs: Optional[dict]
+    ) -> tuple[str, Optional[SynapticUncertaintySettings]]:
+        """Resolve a learning kind into the gradient it descends and its settings.
+
+        ``'synaptic_uncertainty'`` names both the weight-belief rule and the
+        gradient it descends, so the kind comes back unchanged either way. What
+        selecting it adds is its settings, a step size taken from the belief
+        rather than an optimiser, and the belief installed on the
+        weight-carrying elements, which this does. Every other kind is a plain
+        gradient and carries no settings.
+
+        Parameters
+        ----------
+        learning_kind :
+            The kind requested by :meth:`fit` or :meth:`batch_update`.
+        learning_kwargs :
+            Settings for the belief rule, resolved by
+            :func:`~pyhgf.updates.vectorized.learning.resolve_synaptic_uncertainty_settings`.
+            Only meaningful for ``'synaptic_uncertainty'``.
+
+        Returns
+        -------
+        tuple
+            ``(gradient_kind, settings)``, the second being ``None`` for every
+            kind but ``'synaptic_uncertainty'``.
+        """
+        if learning_kind != "synaptic_uncertainty":
+            if learning_kwargs:
+                raise ValueError(
+                    "learning_kwargs is only used by "
+                    f"learning_kind='synaptic_uncertainty', not by {learning_kind!r}."
+                )
+            return learning_kind, None
+
+        # Resolved before the belief is installed, so invalid settings raise
+        # without leaving the network half-configured.
+        settings = resolve_synaptic_uncertainty_settings(learning_kwargs)
+        self.install_weight_belief()
+        return learning_kind, settings
 
     def _require_deep_backend(self, method: str) -> None:
         """Reject deep-network entry points on a continuous network."""
@@ -1265,8 +1376,9 @@ class DeepNetwork:
         self,
         x: Union[np.ndarray, jnp.ndarray],
         y: Union[np.ndarray, jnp.ndarray],
-        optimizer: optax.GradientTransformation,
+        optimizer: Optional[optax.GradientTransformation] = None,
         learning_kind: str = "precision_weighted",
+        learning_kwargs: Optional[dict] = None,
         record: Optional[tuple] = None,
         weight_update: bool = True,
         time_step: float = 1.0,
@@ -1288,7 +1400,7 @@ class DeepNetwork:
             ``lr="adam"`` → ``optimizer=optax.adam(1e-3)``.
         learning_kind :
             Gradient computation mode passed to
-            :func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient`:
+            :func:`~pyhgf.updates.vectorized.learning.learning_weights_vectorized`:
             ``"standard"`` or ``"precision_weighted"`` (default), both reading
             the settled beliefs, strictly local per edge.
         record :
@@ -1335,6 +1447,16 @@ class DeepNetwork:
                     f"Unknown record field(s) {invalid}. Valid: {sorted(valid_fields)}."
                 )
 
+        gradient_kind, synaptic_uncertainty_settings = self._resolve_learning(
+            learning_kind, learning_kwargs
+        )
+
+        if synaptic_uncertainty_settings is None and optimizer is None:
+            raise ValueError(
+                f"learning_kind={learning_kind!r} needs an optimizer. Pass one, "
+                "or use learning_kind='synaptic_uncertainty', whose step size "
+                "is the belief's own variance."
+            )
         self._ensure_optimizer_state(optimizer)
 
         x = jnp.asarray(x)
@@ -1344,11 +1466,12 @@ class DeepNetwork:
             (self.state, self.opt_state),
             (x, y),
             optimizer,
-            learning_kind,
+            gradient_kind,
             weight_update,
             record_tuple,
             float(time_step),
             update_precisions,
+            synaptic_uncertainty_settings,
         )
 
         if record_tuple:
@@ -1358,7 +1481,7 @@ class DeepNetwork:
             self.predictions = step_output
 
         if check_gradient_health and weight_update:
-            self._warn_if_gradients_dead(x[-1], y[-1], learning_kind)
+            self._warn_if_gradients_dead(x[-1], y[-1], gradient_kind)
 
         return self
 
@@ -1400,9 +1523,7 @@ class DeepNetwork:
         swept = update_sweep(
             prediction_sweep(self.state, jnp.asarray(x)), jnp.asarray(y)
         )
-        factors = _weight_gradients(
-            swept, learning_kind, kernel=vectorized_weight_gradient_factors
-        )
+        factors = _weight_quantities(swept, learning_kind)
         magnitudes = [
             None if f is None else float(np.abs(np.asarray(f[0])).max())
             for f in factors
@@ -1644,6 +1765,7 @@ class DeepNetwork:
         y: Union[np.ndarray, jnp.ndarray],
         optimizer: Optional[optax.GradientTransformation] = None,
         learning_kind: str = "precision_weighted",
+        learning_kwargs: Optional[dict] = None,
         update_precisions: bool = True,
         time_step: float = 1.0,
         predicted: Optional[tuple] = None,
@@ -1709,6 +1831,10 @@ class DeepNetwork:
                 "(batch, n_features)."
             )
 
+        gradient_kind, synaptic_uncertainty_settings = self._resolve_learning(
+            learning_kind, learning_kwargs
+        )
+
         self._ensure_optimizer_state(optimizer)
 
         self.state, self.opt_state, self.input_errors = batch_step(
@@ -1717,11 +1843,12 @@ class DeepNetwork:
             x,
             y,
             optimizer=optimizer,
-            learning_kind=learning_kind,
+            learning_kind=gradient_kind,
             update_precisions=update_precisions,
             time_step=float(time_step),
             predicted=predicted,
             sample_weight=None if sample_weight is None else jnp.asarray(sample_weight),
+            synaptic_uncertainty_settings=synaptic_uncertainty_settings,
         )
         return self
 

--- a/pyhgf/model/fused.py
+++ b/pyhgf/model/fused.py
@@ -61,7 +61,7 @@ class _Core(NamedTuple):
 
     init_state: Any
     forward: Callable[[Any, jnp.ndarray], tuple[jnp.ndarray, Any]]
-    backward: Callable[[Any, Any, jnp.ndarray], tuple[jnp.ndarray, Any, tuple]]
+    backward: Callable[..., tuple[jnp.ndarray, Any, tuple]]
     write_back: Callable[[Any], None]
 
 
@@ -73,7 +73,8 @@ def _adapter_core(part: DeepNetworkAdapter, path: str) -> _Core:
     re-running the sweep — inside one trace, the handover is free.
     """
     optimizer = part.optimizer
-    learning_kind = part.learning_kind
+    learning_kind = part.gradient_kind
+    synaptic_uncertainty_settings = part.synaptic_uncertainty_settings
     update_precisions = part.update_precisions
     time_step = part.time_step
     layer_sizes = list(part.net.layer_sizes)
@@ -108,6 +109,7 @@ def _adapter_core(part: DeepNetworkAdapter, path: str) -> _Core:
             optimizer=optimizer,
             learning_kind=learning_kind,
             update_precisions=update_precisions,
+            synaptic_uncertainty_settings=synaptic_uncertainty_settings,
             time_step=time_step,
             predicted=states,
         )
@@ -287,13 +289,21 @@ def _attention_core(part: MultiHeadAttention, path: str) -> _Core:
         cache_q, cache_k, cache_v, cache_mix, cache_o = cache
         d_ctx, new_o, report_o = o_core.backward(state_o, cache_o, error)
         d_q, d_k, d_v = _mixing_backward(cache_mix, d_ctx)
-        error_q, new_q, report_q = q_core.backward(state_q, cache_q, d_q)
-        error_k, new_k, report_k = k_core.backward(state_k, cache_k, d_k)
-        error_v, new_v, report_v = v_core.backward(state_v, cache_v, d_v)
+        # Process the three input cores; errors and reports accumulate since they
+        # share the same input.
+        qkv_results = [
+            core.backward(s, c, d)
+            for core, s, c, d in [
+                (q_core, state_q, cache_q, d_q),
+                (k_core, state_k, cache_k, d_k),
+                (v_core, state_v, cache_v, d_v),
+            ]
+        ]
+        errors, new_states, reports = zip(*qkv_results)
         return (
-            error_q + error_k + error_v,
-            (new_q, new_k, new_v, new_o),
-            report_q + report_k + report_v + report_o,
+            errors[0] + errors[1] + errors[2],
+            (*new_states, new_o),
+            report_o + reports[0] + reports[1] + reports[2],
         )
 
     def write_back(state):
@@ -366,6 +376,8 @@ def _gpt_core(part: HybridGPT, path: str) -> _Core:
             )
             reports = reports + report
         if position_core is not None:
+            # The position part sees one row per position, so it receives the
+            # batch mean of the message.
             _, new_pos, report = position_core.backward(
                 state_pos, cache_pos, embedding_error.mean(axis=0)
             )
@@ -407,7 +419,7 @@ def _core(part, path: Optional[str] = None) -> _Core:
 
 
 class FusedPipeline:
-    """Run a part tree, one compiled program per training step.
+    r"""Run a part tree, one compiled program per training step.
 
     Holds every part's mutable state (the network beliefs and weights, the optimiser
     states) as one explicit pytree, and compiles a single step function: forward walk →

--- a/pyhgf/model/hybrid.py
+++ b/pyhgf/model/hybrid.py
@@ -19,8 +19,8 @@ the error at its output and hands the error at its *input* to the part behind it
 Nothing resembling backpropagation runs anywhere: no global computation graph, no
 automatic differentiation.
 
-Error convention: the arrays passed between parts are *descent* errors — the gradient of
-the loss with respect to that signal, the same object a backprop library would hand
+Error convention: the arrays passed between parts are *descent* errors — the gradient
+of the loss with respect to that signal, the same object a backprop library would hand
 around. PyHGF's internal prediction errors follow the opposite, observed-minus-predicted
 convention; the executor converts between the two at the learning part's boundary, in
 exactly one place.
@@ -40,6 +40,7 @@ import optax
 
 from pyhgf.model.deep_network import DeepNetwork
 from pyhgf.model.error_types import DescentError, ObservedMinusPredicted
+from pyhgf.updates.vectorized.learning import resolve_synaptic_uncertainty_settings
 
 __all__ = [
     "PCModule",
@@ -182,16 +183,19 @@ def _gelu_forward(x: jnp.ndarray) -> tuple[jnp.ndarray, tuple]:
     return jax.nn.gelu(x), (x,)
 
 
-def _gelu_backward(cache: tuple, error: jnp.ndarray) -> jnp.ndarray:
+def _gelu_slope(x: jnp.ndarray) -> jnp.ndarray:
     # Derivative of the tanh approximation
     #   gelu(x) = 0.5 x (1 + tanh(c (x + a x^3))),
     #   gelu'(x) = 0.5 (1 + t) + 0.5 x (1 - t^2) c (1 + 3 a x^2),  t = tanh(...).
-    (x,) = cache
     t = jnp.tanh(_GELU_C * (x + _GELU_A * x**3))
-    slope = 0.5 * (1.0 + t) + 0.5 * x * (1.0 - t**2) * _GELU_C * (
+    return 0.5 * (1.0 + t) + 0.5 * x * (1.0 - t**2) * _GELU_C * (
         1.0 + 3.0 * _GELU_A * x**2
     )
-    return error * slope
+
+
+def _gelu_backward(cache: tuple, error: jnp.ndarray) -> jnp.ndarray:
+    (x,) = cache
+    return error * _gelu_slope(x)
 
 
 def gelu_adapter() -> EquinoxAdapter:
@@ -295,6 +299,13 @@ class DeepNetworkAdapter(PCModule):
         weights (the beliefs still update).
     learning_kind :
         Weight-gradient mode, as in :meth:`~pyhgf.model.DeepNetwork.fit`.
+        ``"synaptic_uncertainty"`` selects the weight-belief rule, whose
+        settings come from ``learning_kwargs`` and whose step size is each
+        weight's own belief variance, so ``optimizer`` is then unused.
+    learning_kwargs :
+        Settings of the learning rule, used by
+        ``learning_kind="synaptic_uncertainty"`` (see
+        :func:`pyhgf.updates.vectorized.learning.resolve_synaptic_uncertainty_settings`).
     update_precisions :
         Whether the precision state adapts across batches (see
         :meth:`~pyhgf.model.DeepNetwork.batch_update`). Defaults to False —
@@ -309,14 +320,31 @@ class DeepNetworkAdapter(PCModule):
         net: DeepNetwork,
         optimizer: Optional[optax.GradientTransformation] = None,
         learning_kind: str = "precision_weighted",
+        learning_kwargs: Optional[dict] = None,
         update_precisions: bool = False,
         time_step: float = 1.0,
     ):
         self.net = net
         self.optimizer = optimizer
         self.learning_kind = learning_kind
+        self.learning_kwargs = learning_kwargs
         self.update_precisions = update_precisions
         self.time_step = time_step
+        # The rule is resolved once here rather than per step: the settings are
+        # static, and the executor stages one compiled program per part.
+        if learning_kind != "synaptic_uncertainty":
+            if learning_kwargs:
+                raise ValueError(
+                    "learning_kwargs is only used by "
+                    f"learning_kind='synaptic_uncertainty', not by {learning_kind!r}."
+                )
+            self.gradient_kind, self.synaptic_uncertainty_settings = learning_kind, None
+        else:
+            self.synaptic_uncertainty_settings = resolve_synaptic_uncertainty_settings(
+                learning_kwargs
+            )
+            net.install_weight_belief()
+            self.gradient_kind = "synaptic_uncertainty"
 
     def init_state(self) -> tuple:
         """Return the ``(network, opt_state)`` state pytree.

--- a/pyhgf/model/transplant.py
+++ b/pyhgf/model/transplant.py
@@ -51,12 +51,12 @@ def _weights_with_bias(weight: jnp.ndarray, bias: Optional[jnp.ndarray]) -> jnp.
 
 
 def _set_weights(net: DeepNetwork, weights: dict) -> DeepNetwork:
-    """Replace ``weights_in`` on the given layer indices."""
+    """Replace ``weights_mean`` on the given layer indices."""
     if net.state is None:
         raise ValueError("Add at least one layer before setting weights.")
     elements = list(net.state.layers)
     for i, w in weights.items():
-        elements[i] = dataclasses.replace(elements[i], weights_in=jnp.asarray(w))
+        elements[i] = dataclasses.replace(elements[i], weights_mean=jnp.asarray(w))
     net.state = dataclasses.replace(net.state, layers=tuple(elements))
     return net
 

--- a/pyhgf/typing/vectorised.py
+++ b/pyhgf/typing/vectorised.py
@@ -195,10 +195,10 @@ class LayerParams(eqx.Module):
 class Layer(eqx.Module):
     r"""One layer of the vectorised deep network.
 
-    ``weights_in`` is the matrix connecting the layer *below* (child) into this layer
-    (parent). The bottom layer (index 0) has ``weights_in=None`` because no layer sits
-    below it. Shape: ``(n_child, n_self[+1])``; the optional ``+1`` column carries the
-    bias when ``add_constant_input=True``.
+    ``weights_mean`` holds the *incoming* weights: the matrix connecting the layer
+    *below* (child) into this layer (parent). The bottom layer (index 0) has
+    ``weights_mean=None`` because no layer sits below it. Shape: ``(n_child, n_self[+1])``;
+    the optional ``+1`` column carries the bias when ``add_constant_input=True``.
 
     Parameters
     ----------
@@ -206,9 +206,10 @@ class Layer(eqx.Module):
         The per-layer state (see :py:class:`LayerState`).
     params :
         The per-layer static parameters (see :py:class:`LayerParams`).
-    weights_in :
-        The matrix connecting the layer below (child) into this layer, or `None`
-        for the bottom layer.
+    weights_mean :
+        The incoming weights, i.e. the matrix connecting the layer below (child)
+        into this layer, or `None` for the bottom layer. Also the mean of each
+        weight's belief where one is installed.
     coupling_fn :
         The coupling function applied to the incoming weights.
     add_constant_input :
@@ -222,17 +223,23 @@ class Layer(eqx.Module):
     kind :
         The kind of layer, one of ``"volatile"``, ``"binary"``, ``"categorical"``,
         or ``"continuous"``.
+    weights_precision_delta :
+        Weight-belief precision, the second parameter of the belief each weight
+        carries: ``weights_mean`` is the belief's mean and this its accumulated
+        precision **above the prior**, same shape. The delta over the prior is
+        stored rather than the precision itself because it starts at zero, so a
+        per-step increment far below the prior precision accumulates exactly.
     value_child_idx :
         Continuous layers only — index (into ``Network.layers``) of the layer this
-        layer is the *value parent* of, or ``None``. ``weights_in`` then connects
+        layer is the *value parent* of, or ``None``. ``weights_mean`` then connects
         that child into this layer, shape ``(n_child, n_self)``, and enters the
         drift of the child's predicted mean. The chain convention of volatile
-        networks (``weights_in`` always connects the layer directly below) is a
+        networks (``weights_mean`` always connects the layer directly below) is a
         special case with ``value_child_idx = self_index - 1``.
     volatility_child_idx :
         Continuous layers only — index of the layer this layer is the *volatility
-        parent* of, or ``None``. ``volatility_weights_in`` connects that child.
-    volatility_weights_in :
+        parent* of, or ``None``. ``volatility_weights`` connects that child.
+    volatility_weights :
         Volatility-coupling matrix :math:`\kappa`, shape ``(n_child, n_self)``,
         connecting the volatility child named by ``volatility_child_idx`` into
         this layer. Fixed at construction — never part of the learned weights
@@ -241,7 +248,7 @@ class Layer(eqx.Module):
 
     state: LayerState
     params: LayerParams
-    weights_in: Optional[Array]
+    weights_mean: Optional[Array]
     coupling_fn: Callable = field(static=True)
     add_constant_input: bool = field(static=True)
     has_volatility_parent: bool = field(static=True)
@@ -250,16 +257,17 @@ class Layer(eqx.Module):
     kind: str = field(
         static=True
     )  # "volatile" | "binary" | "categorical" | "continuous"
+    weights_precision_delta: Optional[Array] = None
     value_child_idx: Optional[int] = field(static=True, default=None)
     volatility_child_idx: Optional[int] = field(static=True, default=None)
-    volatility_weights_in: Optional[Array] = None
+    volatility_weights: Optional[Array] = None
 
 
 class LayerStack(eqx.Module):
     """N identical layers stacked into one PyTree with a leading ``(N,)`` axis.
 
     ``state``/``params`` have leading axis ``N`` (each field shape goes from
-    ``(n_nodes,)`` to ``(N, n_nodes)``). ``weights_in`` goes from
+    ``(n_nodes,)`` to ``(N, n_nodes)``). ``weights_mean`` goes from
     ``(n_child, n_self[+1])`` to ``(N, n_child, n_self[+1])``. Slice index 0 is the
     *bottommost* slice in the stack (closest to layer 0 of the network); slice ``N-1``
     is the topmost.
@@ -267,8 +275,8 @@ class LayerStack(eqx.Module):
     Validation constraints, enforced at build time:
 
     * The layer immediately below the stack must have the same node count as the stack
-    width (so ``weights_in[0]`` shape matches).
-    * ``weights_in[k]`` for k > 0 is a square ``(W, W+bias)`` block connecting slice k
+    width (so ``weights_mean[0]`` shape matches).
+    * ``weights_mean[k]`` for k > 0 is a square ``(W, W+bias)`` block connecting slice k
     (parent) to slice k-1 (child) within the stack.
 
     Parameters
@@ -278,7 +286,7 @@ class LayerStack(eqx.Module):
     params :
         The stacked per-layer static parameters, each field with a leading
         ``(N,)`` axis.
-    weights_in :
+    weights_mean :
         The stacked incoming weight matrices, shape ``(N, n_child, n_self[+1])``.
     coupling_fn :
         The coupling function shared by all stacked layers.
@@ -296,25 +304,29 @@ class LayerStack(eqx.Module):
 
     state: LayerState  # each field shape: (N, n_nodes)
     params: LayerParams  # each field shape: (N, n_nodes)
-    weights_in: Array  # shape: (N, n_child, n_self[+1])
+    weights_mean: Array  # shape: (N, n_child, n_self[+1])
     coupling_fn: Callable = field(static=True)
     add_constant_input: bool = field(static=True)
     has_volatility_parent: bool = field(static=True)
     fully_connected: bool = field(static=True)
     kind: str = field(static=True)
     n_layers: int = field(static=True)
+    #: The stacked weight-belief precisions, shape ``(N, n_child, n_self[+1])``,
+    #: or ``None`` when the stack carries no weight belief. Holds the precision_delta
+    #: over the prior, exactly as :attr:`Layer.weights_precision_delta`.
+    weights_precision_delta: Optional[Array] = None
 
 
 def stack_layers(layers: list) -> LayerStack:
     """Combine N identical ``Layer`` instances into a single ``LayerStack``.
 
     All ``Layer``s must share static-field values (kind, coupling_fn,
-    add_constant_input, has_volatility_parent, fully_connected) and have ``weights_in``
+    add_constant_input, has_volatility_parent, fully_connected) and have ``weights_mean``
     of identical shape. Static fields are taken from the first layer; arrays are stacked
     along a new axis 0.
 
     A ``LayerStack`` carries no DAG topology, so the continuous-layer fields
-    (``value_child_idx``, ``volatility_child_idx``, ``volatility_weights_in``) have no
+    (``value_child_idx``, ``volatility_child_idx``, ``volatility_weights``) have no
     counterpart here and continuous layers cannot be stacked.
 
     Parameters
@@ -350,15 +362,15 @@ def stack_layers(layers: list) -> LayerStack:
                 f"Cannot stack layers with differing coupling_fn identities. "
                 f"Hoist the function to module scope so all layers share it."
             )
-        if lay.weights_in is None:
+        if lay.weights_mean is None:
             raise ValueError(
-                f"layers[{k}] has weights_in=None (bottom layer of the network "
+                f"layers[{k}] has weights_mean=None (bottom layer of the network "
                 f"can't be inside a LayerStack)."
             )
-        if lay.weights_in.shape != first.weights_in.shape:
+        if lay.weights_mean.shape != first.weights_mean.shape:
             raise ValueError(
-                f"layers[{k}].weights_in.shape={lay.weights_in.shape} differs "
-                f"from layers[0].weights_in.shape={first.weights_in.shape}."
+                f"layers[{k}].weights_mean.shape={lay.weights_mean.shape} differs "
+                f"from layers[0].weights_mean.shape={first.weights_mean.shape}."
             )
 
     stacked_state = jax.tree_util.tree_map(
@@ -367,18 +379,33 @@ def stack_layers(layers: list) -> LayerStack:
     stacked_params = jax.tree_util.tree_map(
         lambda *xs: jnp.stack(xs), *(lay.params for lay in layers)
     )
-    stacked_weights = jnp.stack([lay.weights_in for lay in layers])
+    stacked_weights = jnp.stack([lay.weights_mean for lay in layers])
+    # A belief is stacked only when every slice carries one, since the stacked
+    # field is one array across the whole stack.
+    carries_belief = [lay.weights_precision_delta is not None for lay in layers]
+    if any(carries_belief) and not all(carries_belief):
+        raise ValueError(
+            "Cannot stack layers where only some carry a weight belief: "
+            f"{sum(carries_belief)} of {len(layers)} have "
+            "weights_precision_delta. Install it on every layer or none."
+        )
+    stacked_precision = (
+        jnp.stack([lay.weights_precision_delta for lay in layers])
+        if all(carries_belief)
+        else None
+    )
 
     return LayerStack(
         state=stacked_state,
         params=stacked_params,
-        weights_in=stacked_weights,
+        weights_mean=stacked_weights,
         coupling_fn=first.coupling_fn,
         add_constant_input=first.add_constant_input,
         has_volatility_parent=first.has_volatility_parent,
         fully_connected=first.fully_connected,
         kind=first.kind,
         n_layers=len(layers),
+        weights_precision_delta=stacked_precision,
     )
 
 
@@ -449,13 +476,13 @@ class Network(eqx.Module):
         return out
 
     def weights_tuple(self) -> tuple:
-        """Per-element ``weights_in`` tuple, matched 1:1 to ``self.layers``."""
-        return tuple(elem.weights_in for elem in self.layers)
+        """Per-element ``weights_mean`` tuple, matched 1:1 to ``self.layers``."""
+        return tuple(elem.weights_mean for elem in self.layers)
 
     # ------------------------------------------------------------------
     # Legacy-shape views used by existing tests and the Rust-parity
     # cross-check. These are not used in the hot path — the kernels read
-    # ``layer.state`` / ``layer.weights_in`` directly. For ``LayerStack``
+    # ``layer.state`` / ``layer.weights_mean`` directly. For ``LayerStack``
     # elements these views flatten the stack into its constituent slices
     # so consumers see the unrolled shape.
     # ------------------------------------------------------------------
@@ -471,9 +498,9 @@ class Network(eqx.Module):
         for elem in self.layers:
             if isinstance(elem, LayerStack):
                 for k in range(elem.n_layers):
-                    out.append(elem.weights_in[k])
-            elif elem.weights_in is not None:
-                out.append(elem.weights_in)
+                    out.append(elem.weights_mean[k])
+            elif elem.weights_mean is not None:
+                out.append(elem.weights_mean)
         return tuple(out)
 
     @property

--- a/pyhgf/updates/vectorized/learning.py
+++ b/pyhgf/updates/vectorized/learning.py
@@ -3,127 +3,141 @@
 
 """Vectorized weight learning for deep predictive coding networks."""
 
-from typing import Callable
+from typing import Callable, NamedTuple, Optional, Union
 
 import jax.numpy as jnp
 
 from pyhgf.typing.vectorised import LayerState
 
-# The accepted weight-update kinds. Both share the same base term and factorise
-# into a child-side and a parent-side vector (a rank-one product), which is why
-# the gradient below is assembled as a single outer product.
-SEPARABLE_KINDS: tuple = ("standard", "precision_weighted")
+# The accepted weight-update kinds. All three share the same base term and
+# factorise into a child-side and a parent-side vector (a rank-one product),
+# which is why the gradient below is assembled as a single outer product.
+SEPARABLE_KINDS: tuple = ("standard", "precision_weighted", "synaptic_uncertainty")
+
+#: Floor applied to precisions before any division.
+_EPS = 1e-30
 
 
-def vectorized_weight_gradient(
+def learning_weights_vectorized(
     parent_state: LayerState,
     child_state: LayerState,
     coupling_fn: Callable,
     kind: str = "precision_weighted",
     parent_has_constant: bool = False,
-    child_is_binary: bool = False,
-) -> jnp.ndarray:
-    r"""Per-layer weight gradient for the vectorised deep network.
+    child_kind: str = "continuous",
+) -> tuple:
+    r"""Per-layer weight-learning factors for the vectorised deep network.
 
-    Returns the *descent* gradient for the weight matrix. Sign-flipped from the natural
-    "ascent" formulation so it composes with standard optax (`apply_updates(weights,
-    updates)` performs ``weights + updates``; `optax.sgd(lr).update(grad, state, w)`
-    returns ``-lr * grad``; together they reproduce the legacy ``weights + lr * g``
-    rule with ``g = -grad``).
+    The single entry point of this module. One weight update has two halves and
+    this returns the pieces of both: the descent gradient that moves the
+    weight's mean, and the importance increment that raises its precision. They
+    are the first and second derivative of one layer-local energy, computed in
+    one pass rather than selected between.
 
-    The two *kind* values share the same base term, the value prediction error
-    :math:`\delta = \mu_\text{child} - \hat{\mu}_\text{child}` times the coupled
-    parent activation :math:`a = g(\mu_\text{parent})`; they differ only in what
-    scales it. Both are strictly *local*: the update for one weight only reads
-    the prediction error and precision at its child and the activation at its
-    parent. No reduction over other parents or children in the layer.
+    Both are rank-one and **share their parent-side factor**. The gradient is
+    :math:`u \otimes h` and the increment is :math:`p \otimes h^2`, with the
+    same coupled parent activation :math:`h_i = g(\mu_i)`, so three vectors
+    carry both quantities. Returning factors rather than assembled matrices
+    lets a batched caller average over samples and contract once
+    (``einsum('bi,bj->ij') / batch``): the same arithmetic, without
+    materialising one weight-matrix-sized array per sample.
 
-    - **standard** (``kind="standard"``) — the raw gradient of an *unweighted*
-      squared error, no metric:
-      :math:`g = \delta \otimes a`.
-      This coincides with the free-energy gradient only when the child precision
-      is one (e.g. the unit-precision output / categorical convention).
+    Both are strictly *local*: what one weight gets reads only the prediction
+    error and precision at its child and the activation at its parent, never a
+    reduction over the other parents or children in the layer.
 
-    - **precision_weighted** (``kind="precision_weighted"``) — the free-energy
-      gradient weighted by the child's *posterior* precision:
-      :math:`g = \delta \otimes a \cdot \pi_\text{child}`.
-      This is the **backprop-parity** mode. A moved interior belief shifts by
-      (routed error) / posterior precision, so weighting by that same posterior
-      precision cancels the division and reproduces the backpropagated gradient
-      node-for-node at *any* precision setting, not only the pinned recipe.
+    **The child-side gradient factor** starts from the value prediction error
+    :math:`\delta = \mu_\text{child} - \hat{\mu}_\text{child}`, and *kind*
+    decides what scales it:
+
+    - ``"standard"`` takes :math:`\delta` alone, the raw gradient of an
+      *unweighted* squared error. This coincides with the free-energy gradient
+      only where the child precision is one (the unit-precision output or
+      categorical convention).
+    - ``"precision_weighted"`` scales by the child's *posterior* precision,
+      :math:`\delta\,\pi_a`. This is the **backprop-parity** mode: a moved
+      interior belief shifts by (routed error) / posterior precision, so
+      weighting by that same posterior precision cancels the division and
+      reproduces the backpropagated gradient node for node at *any* precision
+      setting.
+    - ``"synaptic_uncertainty"`` charges the process noise between the weight and
+      its child on top, :math:`\delta\,\pi_a / (1 + \Omega_a \xi_a)`, so the
+      gradient and the increment become the two derivatives of one energy.
+      This is the kind the weight-belief rule descends, and the only one it
+      can: dividing it by the weight's own precision is the Gaussian
+      posterior step, so both halves of that update read the same evidence.
+      It is *not* backprop parity.
+
+    A binary child drops the precision factor either way: its ``precision``
+    field holds the Bernoulli variance :math:`p(1-p)`, which cancels through
+    the sigmoid in the gradient, so keeping it would count the same term
+    twice. That cancellation belongs to the *first* derivative only, and the
+    curvature below keeps it.
+
+    **The child-side importance factor** is the exact Hessian diagonal of the
+    layer-local variational energy: that energy is exactly quadratic in the
+    weights for any coupling function, because the coupling acts on the
+    activation while the map :math:`w_{ai} \mapsto w_{ai} h_i` stays linear, so
+    one observation adds :math:`\tilde{\xi}_a h_i^2` with no approximation and
+    no sampling. Where the evidence comes from depends on the child:
+
+    - A **binary** or **categorical** child is where the data are clamped, so
+      the evidence is the curvature of its own likelihood, per unit
+      :math:`p_a(1 - p_a)` with :math:`p_a` the child's expected mean. For the
+      categorical case the Hessian of the log-likelihood with respect to the
+      logits is :math:`\operatorname{diag}(\mathbf{p}) -
+      \mathbf{p}\mathbf{p}^{\top}`, whose diagonal is that expression. No
+      label enters it, since averaging the outer product of the residual over
+      labels drawn from the model returns the same matrix, so this is the
+      model's own expected curvature rather than an estimate built from
+      observed errors.
+    - A **continuous** child passes on the evidence it received from below,
+      softened by the process noise it had to cross,
+      :math:`\tilde\xi_a = (1/\xi_a + \Omega_a)^{-1}`. Both parts are already
+      cached by the sweeps: :math:`\xi_a = \pi_a - \tilde\pi_a`, the posterior
+      precision minus the marginal predicted precision, because a Gaussian
+      posterior precision is its prior plus its likelihood; and
+      :math:`\Omega_a = \gamma_a / \tilde\pi_a`, recovered from the effective
+      precision the prediction sweep writes as
+      :math:`\gamma_a = \Omega_a \tilde\pi_a`. Softening by :math:`\Omega_a`
+      alone is what distinguishes this from the conditional predicted
+      precision :math:`\hat\pi_a`, which softens by
+      :math:`1/\pi_a^{\text{prev}} + \Omega_a` and so also carries the node's
+      own prior variance from the previous step: information about the same
+      quantity for a time series, but about a *different* sample's activation
+      for exchangeable samples.
 
     Parameters
     ----------
     parent_state :
         Current state of the parent layer.
     child_state :
-        Current state of the child layer (with observations).
+        Current state of the child layer (with observations), after the update
+        sweep has written its posterior.
     coupling_fn :
         Coupling function applied to parent means.
     kind :
-        Gradient computation mode.
+        The metric the gradient is expressed in, one of
+        :data:`SEPARABLE_KINDS`. It also sets the importance convention:
+        ``"standard"`` uses unit observation precision on both halves.
     parent_has_constant :
         If True, the parent layer has a constant input node (mean = 1.0,
         precision = 1.0) appended to its activations after coupling.
-    child_is_binary :
-        If True, the child layer is a binary node, so the redundant precision
-        factor is dropped in ``precision_weighted`` (the Bernoulli variance
-        cancels through the sigmoid in the gradient).
+    child_kind :
+        The child layer's node kind, ``"binary"``, ``"categorical"`` or
+        anything else for a continuous one.
 
     Returns
     -------
-    grad :
-        Descent gradient, same shape as ``weights``. NaN / inf entries are
-        zeroed out so optax does not propagate them through its moment
+    factors :
+        The triple ``(u, h, p)``. The child-side gradient factor :math:`u` and
+        the child-side importance factor
+        :math:`p` have shape ``(n_children,)``; the shared parent-side factor
+        :math:`h` has shape ``(n_parents[+1],)``. The gradient is
+        ``u[:, None] * h[None, :]`` and the increment
+        ``p[:, None] * (h ** 2)[None, :]``. Non-finite entries are zeroed, so
+        optax never propagates a NaN or an inf through its moment
         accumulators.
-
-    Raises
-    ------
-    ValueError
-        If *kind* is unrecognised.
-    """
-    u, v = vectorized_weight_gradient_factors(
-        parent_state,
-        child_state,
-        coupling_fn,
-        kind=kind,
-        parent_has_constant=parent_has_constant,
-        child_is_binary=child_is_binary,
-    )
-    return u[:, None] * v[None, :]
-
-
-def vectorized_weight_gradient_factors(
-    parent_state: LayerState,
-    child_state: LayerState,
-    coupling_fn: Callable,
-    kind: str = "precision_weighted",
-    parent_has_constant: bool = False,
-    child_is_binary: bool = False,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """Child- and parent-side factors of the weight gradient.
-
-    The descent gradient of :func:`vectorized_weight_gradient` is a rank-one
-    product, ``grad = u[:, None] * v[None, :]``. Returning the two vectors
-    instead of their product lets a batched caller average gradients over many
-    samples with a single contraction (``einsum('bi,bj->ij') / batch``) — the
-    same arithmetic, but without materialising one weight-matrix-sized gradient
-    per sample, which is what dominates memory traffic at scale.
-
-    Non-finite entries are zeroed on the factors, matching the per-entry
-    zeroing of :func:`vectorized_weight_gradient` for vector-borne NaN/inf.
-
-    Parameters
-    ----------
-    parent_state, child_state, coupling_fn, kind, parent_has_constant, child_is_binary :
-        As in :func:`vectorized_weight_gradient`.
-
-    Returns
-    -------
-    (u, v) :
-        Child-side factor, shape ``(n_children,)``, and parent-side factor,
-        shape ``(n_parents[+1],)``, such that ``u[:, None] * v[None, :]``
-        equals the descent gradient.
 
     Raises
     ------
@@ -133,22 +147,259 @@ def vectorized_weight_gradient_factors(
     if kind not in SEPARABLE_KINDS:
         raise ValueError(f"Unknown kind '{kind}'. Expected one of {SEPARABLE_KINDS}.")
 
-    pe = child_state.mean - child_state.expected_mean
-    coupled_parent = coupling_fn(parent_state.mean)
+    # The shared parent-side factor, h_i = g(mu_i). A constant input node
+    # contributes a fixed activation of 1.0, so its weight counts as usage 1.
+    h = coupling_fn(parent_state.mean)
     if parent_has_constant:
-        coupled_parent = jnp.concatenate([coupled_parent, jnp.ones(1)])
+        h = jnp.concatenate([h, jnp.ones(1)])
+    h = jnp.where(jnp.isfinite(h), h, 0.0)
 
-    # The gradient is the outer product of a child-side factor (the prediction
-    # error, scaled by the child's posterior precision in ``precision_weighted``)
-    # and a parent-side factor (the coupled parent activation). NaN / inf are
-    # zeroed on each factor so optax does not propagate them.
-    u = pe
-    v = coupled_parent
-    if kind == "precision_weighted" and not child_is_binary:
-        u = u * child_state.precision  # posterior precision (backprop-parity gradient)
+    # The evidence the child received from below, and the factor by which the
+    # process noise between the weight and the child attenuates it. Both halves
+    # of the update read these, so they are formed once. The evidence is
+    # floored at zero: clipping can drive a posterior precision below its
+    # prediction, which must not turn the increment into a subtraction.
+    evidence = child_state.precision - child_state.expected_precision
+    floored = jnp.maximum(evidence, 0.0)
+    tonic = child_state.effective_precision / jnp.maximum(
+        child_state.expected_precision, _EPS
+    )
+    softening = 1.0 / (1.0 + tonic * floored)
 
-    u = jnp.where(jnp.isfinite(u), u, 0.0)
-    v = jnp.where(jnp.isfinite(v), v, 0.0)
+    # Child-side gradient factor, in descent form: sign-flipped from the
+    # natural "ascent" formulation so it composes with standard optax
+    # (apply_updates performs weights + updates, and sgd(lr).update returns
+    # -lr * grad).
+    u = child_state.mean - child_state.expected_mean
+    if kind != "standard" and child_kind != "binary":
+        u = u * child_state.precision  # posterior precision
+        if kind == "synaptic_uncertainty":
+            u = u * softening
+    u = -jnp.where(jnp.isfinite(u), u, 0.0)
 
-    # Descent sign, folded into the child-side factor.
-    return -u, v
+    # Child-side importance factor. A caller advancing only the means ignores
+    # it; the two array operations below are removed with it by dead-code
+    # elimination, so gating them on a flag would buy nothing.
+    if kind == "standard":
+        p = jnp.ones_like(child_state.mean)
+    elif child_kind in ("binary", "categorical"):
+        # Clamped discrete child: the curvature of its own likelihood.
+        prob = child_state.expected_mean
+        p = prob * (1.0 - prob)
+    else:
+        # A clamped continuous layer receives no message from below, so no
+        # evidence arrives and its own precision stands in. That fallback is
+        # the uniform clamp-precision convention and carries no per-unit
+        # curvature; seeding such a layer with the true curvature of its
+        # likelihood is separate work.
+        p = jnp.where(evidence > 0.0, floored * softening, child_state.precision)
+    p = jnp.where(jnp.isfinite(p), p, 0.0)
+
+    return u, h, p
+
+
+# ------------------------------------------------------ synaptic uncertainty
+
+#: Settings of the weight-belief rule and their defaults, as
+#: ``learning_kwargs`` accepts them (see :func:`resolve_synaptic_uncertainty_settings`).
+SYNAPTIC_UNCERTAINTY_DEFAULTS: dict = {
+    "window": None,
+    "prior_variance": 1.0,
+    "prior_mean": 0.0,
+    "learning_rate": 1.0,
+    "increment_scale": 1.0,
+}
+
+
+class SynapticUncertaintySettings(NamedTuple):
+    r"""Validated settings of the weight-belief rule.
+
+    Built from a ``learning_kwargs`` dictionary by
+    :func:`resolve_synaptic_uncertainty_settings`; every field is documented there.
+    """
+
+    window: float
+    prior_variance: float
+    prior_mean: float
+    learning_rate: float
+    increment_scale: float
+    prior_precision: float
+
+
+def resolve_synaptic_uncertainty_settings(
+    learning_kwargs: Optional[dict] = None,
+) -> SynapticUncertaintySettings:
+    r"""Validate the weight-belief rule's settings and fill in the defaults.
+
+    Each weight carries a Gaussian belief: the weight itself is the belief's
+    mean and the layer's ``weights_precision_delta`` its precision above the
+    prior. One update step does two things.
+
+    **Mean.** The update is :math:`\Delta w = -\alpha g/\pi + \text{reversion}`,
+    the incoming descent gradient :math:`g` divided by the weight's precision
+    and scaled by ``learning_rate`` :math:`\alpha`, plus a pull of the mean
+    toward ``prior_mean``. At the start :math:`\pi = \pi_p` everywhere, so the
+    rule begins as plain gradient descent at rate
+    :math:`\alpha \times \texttt{prior\_variance}` and departs from it only as
+    precision accumulates.
+
+    **Precision.** The increment is the curvature the data impose on that
+    weight, delivered as the importance factors of
+    :func:`learning_weights_vectorized` or as a full increment matrix. It then
+    relaxes toward the prior in precision form,
+    :math:`\pi \leftarrow \pi + H - (\pi - \pi_p)/N` with
+    :math:`N = \texttt{window}`. The fixed point is
+    :math:`\pi^\ast = N \bar{H} + \pi_p`, linear in the evidence at every
+    scale, and the mean reversion is precision-scaled,
+    :math:`(\pi_p / (N\pi))(\mu_p - w)`, so a weight the data have pinned is
+    also pulled back more gently.
+
+    Both halves are mean-field: each weight's gradient is divided by its own
+    precision, and the joint structure across the weights feeding one child is
+    not retained.
+
+    Parameters
+    ----------
+    learning_kwargs :
+        The settings, as ``DeepNetwork.fit(learning_kwargs=...)`` takes them.
+        Recognised keys, with the defaults of :data:`SYNAPTIC_UNCERTAINTY_DEFAULTS`:
+
+        ``window``
+            The memory window :math:`N`, in update steps. Importance decays
+            toward the prior at rate :math:`1/N`, so curvature older than
+            roughly :math:`N` steps no longer protects a weight. Required,
+            and at least 1.
+        ``prior_variance``
+            Variance of the per-weight prior belief, :math:`1/\pi_p`. Also the
+            effective learning rate before any importance has accumulated, so a
+            value that trains the model well under plain gradient descent is
+            the natural setting.
+        ``prior_mean``
+            Mean the weights revert toward.
+        ``learning_rate``
+            Multiplier :math:`\alpha` on the gradient part of the mean update.
+            It exists because the rule otherwise has no step size of its own:
+            the effective rate is :math:`\alpha/\pi`, and once the accumulated
+            curvature dominates the prior the rate is pinned at
+            :math:`\alpha/(N\bar{H})`. It sets the overall scale of every step
+            but not the *ratio* between the rate before and after importance
+            accumulates, which is :math:`1 + N\bar{H}/\pi_p` and is the depth
+            of protection the rule applies. It does not scale the reversion,
+            which stays at its :math:`1/N` rate, so ``window`` keeps meaning
+            one thing only: how long importance is remembered.
+        ``increment_scale``
+            Multiplier on the importance increment. It deepens protection
+            without touching anything else: the precision reaches
+            :math:`\pi_p + c\,N\bar{H}`, so the most protected weights slow by
+            :math:`c` times more, while the step size before any importance
+            accumulates, the reversion rate and the window are unchanged. A
+            uniform scale leaves rank orderings unchanged.
+
+        The gradient the rule descends is not among them: it is fixed to
+        ``"synaptic_uncertainty"``.
+
+    Returns
+    -------
+    SynapticUncertaintySettings
+        The validated settings, with the prior precision precomputed.
+
+    Raises
+    ------
+    ValueError
+        If a key is unrecognised, ``window`` is missing or below 1, or a
+        positive quantity is not positive.
+    """
+    settings = dict(SYNAPTIC_UNCERTAINTY_DEFAULTS)
+    given = dict(learning_kwargs or {})
+    unknown = sorted(set(given) - set(SYNAPTIC_UNCERTAINTY_DEFAULTS))
+    if unknown:
+        raise ValueError(
+            "Unknown learning_kwargs for learning_kind="
+            f"'synaptic_uncertainty': {unknown}. "
+            f"Expected a subset of {sorted(SYNAPTIC_UNCERTAINTY_DEFAULTS)}."
+        )
+    settings.update(given)
+
+    if settings["window"] is None:
+        raise ValueError(
+            "learning_kind='synaptic_uncertainty' requires "
+            "learning_kwargs={'window': N, ...}: "
+            "the memory window has no default, since it sets how long "
+            "importance is remembered."
+        )
+    window = float(settings["window"])
+    if window < 1:
+        raise ValueError(f"window must be at least 1, got {window}.")
+    prior_variance = float(settings["prior_variance"])
+    if prior_variance <= 0:
+        raise ValueError(f"prior_variance must be positive, got {prior_variance}.")
+    learning_rate = float(settings["learning_rate"])
+    if learning_rate <= 0:
+        raise ValueError(f"learning_rate must be positive, got {learning_rate}.")
+    increment_scale = float(settings["increment_scale"])
+    if increment_scale <= 0:
+        raise ValueError(f"increment_scale must be positive, got {increment_scale}.")
+    return SynapticUncertaintySettings(
+        window=window,
+        prior_variance=prior_variance,
+        prior_mean=float(settings["prior_mean"]),
+        learning_rate=learning_rate,
+        increment_scale=increment_scale,
+        prior_precision=1.0 / prior_variance,
+    )
+
+
+def vectorized_synaptic_uncertainty_update(
+    weights: jnp.ndarray,
+    precision_delta: jnp.ndarray,
+    gradient: jnp.ndarray,
+    importance,
+    settings: SynapticUncertaintySettings,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    r"""One weight matrix's belief update: new mean, new accumulated precision.
+
+    The rule is stated in :func:`resolve_synaptic_uncertainty_settings`. A
+    ``LayerStack`` carries a leading slice axis on every operand, which the ellipsis
+    broadcasting here handles unchanged.
+
+    Parameters
+    ----------
+    weights :
+        The belief means, i.e. the element's ``weights_mean``.
+    precision_delta :
+        The accumulated precision above the prior, same shape.
+    gradient :
+        The descent gradient, same shape.
+    importance :
+        Either the factor pair ``(p, q)`` of
+        :func:`learning_weights_vectorized`, batch-averaged, whose outer product
+        is the increment; or a full increment matrix of the weights' shape,
+        which is the exact batch contraction the evidence pass delivers.
+    settings :
+        The resolved settings.
+
+    Returns
+    -------
+    tuple of jnp.ndarray
+        The updated weights and the updated accumulated precision.
+    """
+    prior_precision = settings.prior_precision
+    pi = jnp.maximum(precision_delta + prior_precision, _EPS)
+
+    # The mean update divides by the pre-update precision and the reversion is
+    # precision-scaled, both as in the published rule.
+    reversion = (prior_precision / (settings.window * pi)) * (
+        settings.prior_mean - weights
+    )
+    update = -settings.learning_rate * gradient / pi + reversion
+
+    if isinstance(importance, tuple):
+        # Rank-one importance increment H[a, i] = p[a] * q[i].
+        p, q = importance
+        increment = p[..., :, None] * q[..., None, :]
+    else:
+        increment = importance
+    increment = settings.increment_scale * increment
+    new_delta = precision_delta + increment - precision_delta / settings.window
+
+    return weights + update, new_delta

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -37,8 +37,9 @@ from pyhgf.updates.vectorized.continuous import (
     vectorized_continuous_prediction_error,
 )
 from pyhgf.updates.vectorized.learning import (
-    vectorized_weight_gradient,
-    vectorized_weight_gradient_factors,
+    SynapticUncertaintySettings,
+    learning_weights_vectorized,
+    vectorized_synaptic_uncertainty_update,
 )
 from pyhgf.updates.vectorized.volatile import (
     vectorized_layer_posterior_update,
@@ -54,19 +55,19 @@ from pyhgf.updates.vectorized.volatile import (
 
 
 def _stack_slice(stack: LayerStack, index: int):
-    """Return ``(state, params, weights_in)`` of the stack slice at ``index``.
+    """Return ``(state, params, weights_mean)`` of the stack slice at ``index``.
 
     Index ``0`` is the bottommost slice, ``-1`` the topmost.
     """
     state = jax.tree_util.tree_map(lambda x: x[index], stack.state)
     params = jax.tree_util.tree_map(lambda x: x[index], stack.params)
-    return state, params, stack.weights_in[index]
+    return state, params, stack.weights_mean[index]
 
 
 def _parent_view(elem):
     """Treat a ``Layer`` or ``LayerStack`` uniformly when acting as a parent.
 
-    Returns ``(state, weights_in, coupling_fn, add_constant_input)``. The four pieces
+    Returns ``(state, weights_mean, coupling_fn, add_constant_input)``. The four pieces
     ``propagation_step`` needs to predict a child below.
 
     For a ``LayerStack``, the parent is the *bottommost* slice (the slice closest to the
@@ -75,7 +76,7 @@ def _parent_view(elem):
     if isinstance(elem, LayerStack):
         state, _, weights = _stack_slice(elem, 0)
         return state, weights, elem.coupling_fn, elem.add_constant_input
-    return elem.state, elem.weights_in, elem.coupling_fn, elem.add_constant_input
+    return elem.state, elem.weights_mean, elem.coupling_fn, elem.add_constant_input
 
 
 def _child_view(elem):
@@ -164,7 +165,7 @@ def _predict_stack_from_parent(
     for a ``LayerStack`` parent, those of its bottommost slice.
 
     Scan step: predict slice ``k`` from slice ``k+1`` for ``k = N-2 ... 0`` using
-    ``stack.weights_in[k+1]`` and the stack's own coupling function and bias.
+    ``stack.weights_mean[k+1]`` and the stack's own coupling function and bias.
     The scan runs in reverse so the carry threads top-to-bottom through the stack.
     """
     top_slice_state, top_slice_params, _ = _stack_slice(stack, -1)
@@ -184,13 +185,13 @@ def _predict_stack_from_parent(
 
     # xs: per-iteration data for predicting slices N-2 ... 0 from the slice above.
     # At step k, body(parent_state, xs[k]) → predict slice k. The "parent's
-    # weights" used to predict slice k come from slice k+1 — i.e. stack.weights_in[k+1].
+    # weights" used to predict slice k come from slice k+1 — i.e. stack.weights_mean[k+1].
     # A single-slice stack yields zero-length xs: the scan runs no steps and the
     # concatenation below just wraps the top state.
     n = stack.n_layers
     xs_child_state = jax.tree_util.tree_map(lambda x: x[: n - 1], stack.state)
     xs_child_params = jax.tree_util.tree_map(lambda x: x[: n - 1], stack.params)
-    xs_parent_weights = stack.weights_in[1:]  # shape (n-1, ...)
+    xs_parent_weights = stack.weights_mean[1:]  # shape (n-1, ...)
 
     def body(parent_state_carry, k_data):
         child_state, child_params, parent_weights_k = k_data
@@ -313,7 +314,7 @@ def _posterior_pe_layer(
     new_state = vectorized_layer_posterior_update(
         layer=parent.state,
         child=child_state,
-        weights=parent.weights_in,
+        weights=parent.weights_mean,
         coupling_fn=parent.coupling_fn,
         parent_has_constant=parent.add_constant_input,
         max_posterior_precision=max_posterior_precision,
@@ -342,7 +343,7 @@ def _top_precision_only(
     r"""Update the top layer's precision from the layer below, leaving its mean clamped.
 
     The top layer holds the predictors, and its mean is read back by the weight update
-    (:func:`~pyhgf.updates.vectorized.learning.vectorized_weight_gradient_factors`
+    (:func:`~pyhgf.updates.vectorized.learning.learning_weights_vectorized`
     forms the parent-side factor from ``coupling_fn(parent.mean)``). Those weights must
     be learned against the predictors that were actually supplied, so the mean stays
     pinned to ``x`` and only its precision moves.
@@ -364,8 +365,8 @@ def _top_precision_only(
     """
     # Only called for a top element that has a layer below it, so it carries an
     # incoming matrix.
-    assert parent.weights_in is not None
-    weights = parent.weights_in
+    assert parent.weights_mean is not None
+    weights = parent.weights_mean
     if parent.add_constant_input:
         weights = weights[:, :-1]
 
@@ -464,7 +465,7 @@ def _posterior_pe_stack(
     _, new_full_state = jax.lax.scan(
         body,
         init=child_state_init,
-        xs=(stack.state, stack.params, stack.weights_in),
+        xs=(stack.state, stack.params, stack.weights_mean),
     )
     return dataclasses.replace(stack, state=new_full_state)
 
@@ -502,26 +503,26 @@ def _bottomup_posterior_pe(
 # ---------------------------------------------------------------------------
 
 
-def _layer_weight_op(kernel, parent: Layer, child_elem, learning_kind: str):
-    """Apply a per-layer weight kernel to a ``Layer`` parent and its child."""
+def _layer_weight_op(parent: Layer, child_elem, learning_kind: str):
+    """Learning factors for a ``Layer`` parent and its child."""
     child_state, child_kind, _ = _child_view(child_elem)
-    return kernel(
+    return learning_weights_vectorized(
         parent_state=parent.state,
         child_state=child_state,
         coupling_fn=parent.coupling_fn,
         kind=learning_kind,
         parent_has_constant=parent.add_constant_input,
-        child_is_binary=(child_kind == "binary"),
+        child_kind=child_kind,
     )
 
 
-def _stack_weight_op(kernel, stack: LayerStack, child_elem, learning_kind: str):
-    """Apply a per-layer weight kernel to every slice of a ``LayerStack``.
+def _stack_weight_op(stack: LayerStack, child_elem, learning_kind: str):
+    """Learning factors for every slice of a ``LayerStack``.
 
     The child of slice 0 is the layer below the stack (``child_elem``); the child of
     slice k>0 is slice k-1 within the stack. Pre-pend the external child's state to the
     stack's slices ``0 .. N-2`` along axis 0 to form the ``(N, ...)`` child slots, then
-    ``vmap`` the kernel over the N parent slices (``stack.state``) and the child slots.
+    ``vmap`` over the N parent slices (``stack.state``) and the child slots.
     """
     child_state, _, _ = _child_view(child_elem)
     child_state = _match_child_vol_structure(child_state, stack.has_volatility_parent)
@@ -533,23 +534,23 @@ def _stack_weight_op(kernel, stack: LayerStack, child_elem, learning_kind: str):
     )
 
     def per_slice(parent_state, child_state_for_slice):
-        return kernel(
+        return learning_weights_vectorized(
             parent_state=parent_state,
             child_state=child_state_for_slice,
             coupling_fn=stack.coupling_fn,
             kind=learning_kind,
             parent_has_constant=stack.add_constant_input,
-            child_is_binary=False,
+            child_kind="continuous",
         )
 
     return jax.vmap(per_slice)(stack.state, child_states)
 
 
-def _weight_op(kernel, parent_elem, child_elem, learning_kind: str):
-    """Dispatch a per-layer weight kernel on ``Layer`` vs ``LayerStack``."""
+def _weight_op(parent_elem, child_elem, learning_kind: str):
+    """Dispatch the learning factors on ``Layer`` vs ``LayerStack``."""
     if isinstance(parent_elem, LayerStack):
-        return _stack_weight_op(kernel, parent_elem, child_elem, learning_kind)
-    return _layer_weight_op(kernel, parent_elem, child_elem, learning_kind)
+        return _stack_weight_op(parent_elem, child_elem, learning_kind)
+    return _layer_weight_op(parent_elem, child_elem, learning_kind)
 
 
 # ---------------------------------------------------------------------------
@@ -632,10 +633,11 @@ def propagation_step(
     opt_state: optax.OptState,
     inputs: tuple,
     *,
-    optimizer: optax.GradientTransformation,
+    optimizer: Optional[optax.GradientTransformation],
     time_step: float = 1.0,
     learning_kind: str = "precision_weighted",
     weight_update: bool = True,
+    synaptic_uncertainty_settings: Optional[SynapticUncertaintySettings] = None,
 ) -> tuple[tuple[Network, optax.OptState], jnp.ndarray]:
     """Single propagation step through the network.
 
@@ -665,7 +667,7 @@ def propagation_step(
         The time elapsed since the previous step.
     learning_kind :
         The weight-gradient mode passed to
-        :py:func:`pyhgf.updates.vectorized.learning.vectorized_weight_gradient`.
+        :py:func:`pyhgf.updates.vectorized.learning.learning_weights_vectorized`.
     weight_update :
         Whether to apply the weight-learning phase after belief propagation.
 
@@ -687,7 +689,7 @@ def propagation_step(
     # Optional weight-learning phase.
     if weight_update:
         new_network, new_opt_state = _learn_sweep(
-            swept, opt_state, optimizer, learning_kind
+            swept, opt_state, optimizer, learning_kind, synaptic_uncertainty_settings
         )
     else:
         new_network, new_opt_state = swept, opt_state
@@ -705,12 +707,13 @@ def propagation_step(
 def run_scan(
     init_carry: tuple,
     inputs: tuple,
-    optimizer: optax.GradientTransformation,
+    optimizer: Optional[optax.GradientTransformation],
     learning_kind: str,
     weight_update: bool,
     record: tuple,
     time_step: float = 1.0,
     update_precisions: bool = True,
+    synaptic_uncertainty_settings: Optional[SynapticUncertaintySettings] = None,
 ) -> tuple:
     r"""Run ``jax.lax.scan`` over the belief-propagation step.
 
@@ -729,7 +732,7 @@ def run_scan(
         The optax optimiser used for the weight-learning phase.
     learning_kind :
         The weight-gradient mode passed to
-        :py:func:`pyhgf.updates.vectorized.learning.vectorized_weight_gradient`.
+        :py:func:`pyhgf.updates.vectorized.learning.learning_weights_vectorized`.
     weight_update :
         Whether to apply the weight-learning phase at every step.
     record :
@@ -762,6 +765,7 @@ def run_scan(
             time_step=time_step,
             learning_kind=learning_kind,
             weight_update=weight_update,
+            synaptic_uncertainty_settings=synaptic_uncertainty_settings,
         )
         if not update_precisions:
             # Static-cascade mode: precisions are parameters, not filter state. Note
@@ -932,14 +936,14 @@ def _input_prediction_error(network: Network) -> jnp.ndarray:
     top = network.layers[-1]
     if isinstance(top, LayerStack):
         raise NotImplementedError("Top of network must be a Layer, not a LayerStack.")
-    if top.weights_in is None:
+    if top.weights_mean is None:
         raise ValueError(
             "The network has a single layer: there is no layer below the "
             "input layer to route an error from."
         )
     child_state, _, _ = _child_view(network.layers[-2])
 
-    weights = top.weights_in
+    weights = top.weights_mean
     if top.add_constant_input:
         # The bias column connects the constant node, not a real input.
         weights = weights[:, :-1]
@@ -970,24 +974,42 @@ def input_prediction_error(network: Network) -> jnp.ndarray:
     return _input_prediction_error(network)
 
 
-def _weight_gradients(
-    network: Network, learning_kind: str, kernel=vectorized_weight_gradient
-) -> tuple:
-    """Per-element weight gradients, without applying them.
+def _weight_quantities(network: Network, learning_kind: str) -> tuple:
+    """Per-element weight-learning factors, without applying them.
 
     Must run *after* :func:`_update_sweep`, so the per-layer states already carry their
     prediction errors / posteriors. Returns one entry per element, matched 1:1 to
     ``network.layers`` (``None`` for the bottom element, which has no incoming
-    weights). With the default kernel each entry is a gradient in descent form
-    (same shape as the element's ``weights_in``), ready for optax; with
-    :func:`pyhgf.updates.vectorized.learning.vectorized_weight_gradient_factors`
-    each entry is the rank-one factor pair ``(u, v)``.
+    weights); each entry is the factor tuple of
+    :func:`pyhgf.updates.vectorized.learning.learning_weights_vectorized`.
+    Assemble them with :func:`_gradient_matrix` and :func:`_importance_pair`.
     """
     elements = network.layers
     return (None,) + tuple(
-        _weight_op(kernel, elements[i], elements[i - 1], learning_kind)
+        _weight_op(elements[i], elements[i - 1], learning_kind)
         for i in range(1, len(elements))
     )
+
+
+def _gradient_matrix(factors) -> Optional[jnp.ndarray]:
+    """Assemble the descent gradient from one element's factors."""
+    if factors is None:
+        return None
+    u, h = factors[0], factors[1]
+    return u[..., :, None] * h[..., None, :]
+
+
+def _importance_pair(factors) -> Optional[tuple]:
+    """Build the importance factor pair ``(p, h**2)`` from one element's factors.
+
+    The parent side is squared here rather than at the source, since both quantities
+    read the same activation. Squaring can overflow a finite activation, so the non-
+    finite guard is applied after it, matching the child side.
+    """
+    if factors is None:
+        return None
+    squared = factors[1] ** 2
+    return factors[2], jnp.where(jnp.isfinite(squared), squared, 0.0)
 
 
 def _apply_weight_updates(
@@ -996,32 +1018,105 @@ def _apply_weight_updates(
     opt_state: optax.OptState,
     optimizer: optax.GradientTransformation,
 ) -> tuple[Network, optax.OptState]:
-    """One optimiser step on every ``weights_in``, from precomputed gradients."""
+    """One optimiser step on every ``weights_mean``, from precomputed gradients."""
     elements = list(network.layers)
-    weights = tuple(elem.weights_in for elem in elements)
+    weights = tuple(elem.weights_mean for elem in elements)
 
     updates, new_opt_state = optimizer.update(grads, opt_state, weights)
     new_weights = optax.apply_updates(weights, updates)
     for i, new_w in enumerate(new_weights):
         if new_w is not None:
-            elements[i] = dataclasses.replace(elements[i], weights_in=new_w)
+            elements[i] = dataclasses.replace(elements[i], weights_mean=new_w)
 
     return dataclasses.replace(network, layers=tuple(elements)), new_opt_state
+
+
+def _apply_synaptic_uncertainty_updates(
+    network: Network,
+    grads: tuple,
+    importance: tuple,
+    settings: SynapticUncertaintySettings,
+) -> Network:
+    """Advance every weight belief one step, mean and precision together.
+
+    The rule needs no optimiser: the step size is the belief's own variance
+    (see
+    :func:`pyhgf.updates.vectorized.learning.resolve_synaptic_uncertainty_settings`),
+    so the update is applied here and both the mean (``weights_mean``) and the
+    accumulated precision (``weights_precision_delta``) are written back to
+    the element that carries them.
+
+    Parameters
+    ----------
+    network :
+        The network whose beliefs are advanced.
+    grads :
+        One descent gradient per element, ``None`` for the bottom element.
+    importance :
+        One importance entry per element, aligned with ``grads``.
+    settings :
+        The resolved settings of the rule.
+
+    Returns
+    -------
+    Network
+        The network with updated weights and precisions.
+
+    Raises
+    ------
+    ValueError
+        If an element holding weights carries no belief, which means the
+        install step was skipped.
+    """
+    elements = list(network.layers)
+    for i, elem in enumerate(elements):
+        if elem.weights_mean is None or grads[i] is None:
+            continue
+        if elem.weights_precision_delta is None:
+            raise ValueError(
+                f"layers[{i}] holds weights but no weight belief. Install one "
+                "with add_layer(weight_belief=True), or let "
+                "learning_kind='synaptic_uncertainty' install it."
+            )
+        new_weights, new_delta = vectorized_synaptic_uncertainty_update(
+            elem.weights_mean,
+            elem.weights_precision_delta,
+            grads[i],
+            importance[i],
+            settings,
+        )
+        elements[i] = dataclasses.replace(
+            elem, weights_mean=new_weights, weights_precision_delta=new_delta
+        )
+    return dataclasses.replace(network, layers=tuple(elements))
 
 
 def _learn_sweep(
     network: Network,
     opt_state: optax.OptState,
-    optimizer: optax.GradientTransformation,
+    optimizer: Optional[optax.GradientTransformation],
     learning_kind: str = "precision_weighted",
+    synaptic_uncertainty_settings: Optional[SynapticUncertaintySettings] = None,
 ) -> tuple[Network, optax.OptState]:
-    """Weight-learning phase: prediction-error-driven gradients + an optimiser step.
+    """Weight-learning phase: prediction-error-driven gradients, then one step.
 
     Mirrors the weight-update block of :func:`propagation_step`. Must run *after*
     :func:`_update_sweep`, so the per-layer states already carry their prediction errors
-    / posteriors. Updates ``weights_in`` on every element that has them.
+    / posteriors. Updates ``weights_mean`` on every element that has them.
+
+    With ``synaptic_uncertainty_settings`` the weight-belief rule runs instead
+    of the optimiser: the gradients are formed from ``learning_kind`` as usual,
+    the importance increments alongside them, and both the means and the
+    precisions advance. The optimiser state is returned unchanged, since the
+    rule carries none.
     """
-    grads = _weight_gradients(network, learning_kind)
+    factors = _weight_quantities(network, learning_kind)
+    grads = tuple(_gradient_matrix(f) for f in factors)
+    if synaptic_uncertainty_settings is not None:
+        importance = tuple(_importance_pair(f) for f in factors)
+        return _apply_synaptic_uncertainty_updates(
+            network, grads, importance, synaptic_uncertainty_settings
+        ), opt_state
     return _apply_weight_updates(network, grads, opt_state, optimizer)
 
 
@@ -1029,14 +1124,17 @@ def _learn_sweep(
 def learn_sweep(
     network: Network,
     opt_state: optax.OptState,
-    optimizer: optax.GradientTransformation,
+    optimizer: Optional[optax.GradientTransformation],
     learning_kind: str,
+    synaptic_uncertainty_settings: Optional[SynapticUncertaintySettings] = None,
 ) -> tuple[Network, optax.OptState]:
     """JIT-compiled weight-learning phase.
 
     See :func:`_learn_sweep`.
     """
-    return _learn_sweep(network, opt_state, optimizer, learning_kind)
+    return _learn_sweep(
+        network, opt_state, optimizer, learning_kind, synaptic_uncertainty_settings
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1138,7 +1236,7 @@ def sample_step(
         ``(n_output_features,)``.
     learning_kind :
         Weight-gradient mode, as in
-        :func:`pyhgf.updates.vectorized.learning.vectorized_weight_gradient`.
+        :func:`pyhgf.updates.vectorized.learning.learning_weights_vectorized`.
     time_step :
         Inference time step for the prediction sweep.
 
@@ -1161,7 +1259,7 @@ def sample_step(
     )
     return (
         _input_prediction_error(updated),
-        _weight_gradients(updated, learning_kind),
+        tuple(_gradient_matrix(f) for f in _weight_quantities(updated, learning_kind)),
         _precision_increments(network, updated),
     )
 
@@ -1177,6 +1275,7 @@ def _batch_step(
     time_step: float = 1.0,
     predicted: Optional[tuple] = None,
     sample_weight: Optional[jnp.ndarray] = None,
+    synaptic_uncertainty_settings: Optional[SynapticUncertaintySettings] = None,
 ) -> tuple[Network, Optional[optax.OptState], jnp.ndarray]:
     """One batch-synchronous learning step over many samples at once.
 
@@ -1234,6 +1333,13 @@ def _batch_step(
         element). When given, the internal prediction sweep is skipped and
         the update starts from these states — the forward pass a caller has
         already run is not repeated. ``x`` is ignored in that case.
+    synaptic_uncertainty_settings :
+        When given, the weight-belief rule runs in place of ``optimizer``:
+        each element's mean and accumulated precision advance together and
+        the optimiser state is left untouched (see
+        :func:`pyhgf.updates.vectorized.learning.resolve_synaptic_uncertainty_settings`
+        ).
+        ``learning_kind`` still selects the gradient the rule descends.
 
     Returns
     -------
@@ -1257,10 +1363,8 @@ def _batch_step(
     def finish_sample(swept: Network, yi):
         updated = _update_sweep(swept, yi, time_step=time_step)
         factors = None
-        if optimizer is not None:
-            factors = _weight_gradients(
-                updated, learning_kind, kernel=vectorized_weight_gradient_factors
-            )
+        if optimizer is not None or synaptic_uncertainty_settings is not None:
+            factors = _weight_quantities(updated, learning_kind)
         return (
             _input_prediction_error(updated),
             _precision_increments(network, updated),
@@ -1291,11 +1395,22 @@ def _batch_step(
         input_errors, increments, factors = jax.vmap(per_sample_predicted)(predicted, y)
 
     new_network = network
-    if optimizer is not None:
-        mean_grads = tuple(_contract_factors(f, sample_weight) for f in factors)
-        new_network, opt_state = _apply_weight_updates(
-            new_network, mean_grads, opt_state, optimizer
+    if optimizer is not None or synaptic_uncertainty_settings is not None:
+        mean_grads = tuple(
+            None if f is None else _contract_factors((f[0], f[1]), sample_weight)
+            for f in factors
         )
+        if synaptic_uncertainty_settings is not None:
+            importance = tuple(
+                _reduce_importance(_importance_pair(f), sample_weight) for f in factors
+            )
+            new_network = _apply_synaptic_uncertainty_updates(
+                new_network, mean_grads, importance, synaptic_uncertainty_settings
+            )
+        else:
+            new_network, opt_state = _apply_weight_updates(
+                new_network, mean_grads, opt_state, optimizer
+            )
 
     if update_precisions:
         if sample_weight is None:
@@ -1315,6 +1430,33 @@ def _batch_step(
 # Compiled entry point. The unjitted ``_batch_step`` is importable so a larger
 # compiled program (e.g. a fused pipeline step) can inline it.
 batch_step = eqx.filter_jit(_batch_step)
+
+
+def _reduce_importance(imp_factors, sample_weight=None) -> Optional[tuple]:
+    """Batch-mean importance factors from stacked per-sample factors.
+
+    ``imp_factors`` is ``None`` for the bottom element, or a ``(p, q)`` pair with a
+    leading batch axis (see :func:`_importance_pair`). Each side is averaged over the
+    batch separately. For a continuous child the child-side factor is identical across
+    the batch (every sample sweeps from the same state template, and the conditional
+    predicted precision is built from carried precisions and volatility states, not from
+    the sample's values), and a binary child contributes ones, so the outer product of
+    the two means equals the mean of the per-sample outer products.
+
+    ``sample_weight`` follows the semantics of :func:`_contract_factors`: a weighted
+    mean whose denominator is the weight the batch actually carries, so padded rows do
+    not dilute the increment.
+    """
+    if imp_factors is None:
+        return None
+    p, q = imp_factors
+    if sample_weight is None:
+        return p.mean(axis=0), q.mean(axis=0)
+    denominator = jnp.maximum(sample_weight.sum(), 1.0)
+    return (
+        jnp.tensordot(sample_weight, p, axes=(0, 0)) / denominator,
+        jnp.tensordot(sample_weight, q, axes=(0, 0)) / denominator,
+    )
 
 
 def _contract_factors(factors, sample_weight=None) -> Optional[jnp.ndarray]:
@@ -1497,11 +1639,11 @@ def _continuous_prediction_sweep(
             params=elem.params,
             time_step=time_step,
             value_parent_state=None if vp is None else elements[vp].state,
-            weights=None if vp is None else elements[vp].weights_in,
+            weights=None if vp is None else elements[vp].weights_mean,
             coupling_fn=None if vp is None else elements[vp].coupling_fn,
             volatility_parent_state=(None if vlp is None else elements[vlp].state),
             volatility_weights=(
-                None if vlp is None else elements[vlp].volatility_weights_in
+                None if vlp is None else elements[vlp].volatility_weights
             ),
             is_static_leaf=elem.is_input_layer and vlp is None,
         )
@@ -1544,7 +1686,7 @@ def _continuous_update_sweep(
             child_elem = elements[elem.value_child_idx]
             value_child = ValueChild(
                 state=child_elem.state,
-                weights=elem.weights_in,
+                weights=elem.weights_mean,
                 coupling_fn=elem.coupling_fn,
                 # Only layer 0 is clamped, and the update loop below skips it,
                 # so its posterior precision is the one that never moves.
@@ -1556,7 +1698,7 @@ def _continuous_update_sweep(
             child_elem = elements[elem.volatility_child_idx]
             volatility_child = VolatilityChild(
                 state=child_elem.state,
-                kappa=elem.volatility_weights_in,
+                kappa=elem.volatility_weights,
                 params=child_elem.params,
             )
 

--- a/pyhgf/utils/weight_initialisation.py
+++ b/pyhgf/utils/weight_initialisation.py
@@ -182,7 +182,7 @@ def _init_matrix(
     seed: int,
     kwargs: dict,
 ) -> jnp.ndarray:
-    r"""Draw one ``weights_in`` matrix, keeping the bias column out of the statistics.
+    r"""Draw one ``weights_mean`` matrix, keeping the bias column out of the statistics.
 
     The bias column is not a connection to a parent, so it takes no part in either
     half of an initialisation scheme. It is **excluded from the fan-in** and **initialised

--- a/tests/test_deepnetwork.py
+++ b/tests/test_deepnetwork.py
@@ -283,7 +283,7 @@ def test_orthogonal_initialisation_survives_the_reshape():
 
     shapes = []
     for layer in net.state.layers[1:]:
-        weights = np.asarray(layer.weights_in)
+        weights = np.asarray(layer.weights_mean)
         if layer.add_constant_input:
             # The bias column is not a connection and takes no part in the
             # orthogonality; it is zeroed by ``_init_matrix``.
@@ -795,10 +795,10 @@ def test_constant_input_is_linearly_coupled():
     )
     elements = list(net.state.layers)
     elements[1] = dataclasses.replace(
-        elements[1], weights_in=jnp.concatenate([w1, b1[:, None]], axis=1)
+        elements[1], weights_mean=jnp.concatenate([w1, b1[:, None]], axis=1)
     )
     elements[2] = dataclasses.replace(
-        elements[2], weights_in=jnp.concatenate([w2, b2[:, None]], axis=1)
+        elements[2], weights_mean=jnp.concatenate([w2, b2[:, None]], axis=1)
     )
     net.state = dataclasses.replace(net.state, layers=tuple(elements))
 
@@ -807,10 +807,10 @@ def test_constant_input_is_linearly_coupled():
 
 
 def _set_weights(net: DeepNetwork, weights: dict) -> DeepNetwork:
-    """Replace ``weights_in`` on the given layers (index -> matrix)."""
+    """Replace ``weights_mean`` on the given layers (index -> matrix)."""
     elements = list(net.state.layers)
     for i, w in weights.items():
-        elements[i] = dataclasses.replace(elements[i], weights_in=jnp.asarray(w))
+        elements[i] = dataclasses.replace(elements[i], weights_mean=jnp.asarray(w))
     net.state = dataclasses.replace(net.state, layers=tuple(elements))
     return net
 
@@ -923,8 +923,8 @@ def test_ff_block_single_sweep_matches_backprop():
     )
 
     # The applied weight change divided by -lr is the descent gradient.
-    d_w1 = -(net.state.layers[1].weights_in - w1) / lr
-    d_w2 = -(net.state.layers[2].weights_in - w2) / lr
+    d_w1 = -(net.state.layers[1].weights_mean - w1) / lr
+    d_w2 = -(net.state.layers[2].weights_mean - w2) / lr
 
     assert _norm_rel_err(d_w1, g_w1) < 1e-2
     assert _norm_rel_err(d_w2, g_w2) < 1e-2
@@ -957,7 +957,7 @@ def test_input_side_gradient_precision_cancellation():
     net.prediction(x).update(
         y, optimizer=optax.sgd(lr), learning_kind="precision_weighted"
     )
-    d_w2 = -(net.state.layers[2].weights_in - w2) / lr
+    d_w2 = -(net.state.layers[2].weights_mean - w2) / lr
 
     assert _norm_rel_err(d_w2, g_w2) < 1e-3
 
@@ -1016,7 +1016,8 @@ def test_sample_step_matches_stateful_api():
     # loses ~(weight magnitude · float32 eps) / lr of absolute precision.
     for k in (1, 2):
         implied = (
-            -(net_learn.state.layers[k].weights_in - template.layers[k].weights_in) / lr
+            -(net_learn.state.layers[k].weights_mean - template.layers[k].weights_mean)
+            / lr
         )
         np.testing.assert_allclose(grads[k], implied, rtol=1e-3, atol=1e-4)
 
@@ -1053,8 +1054,8 @@ def test_batch_update_averages_and_is_batch_size_invariant():
 
     for k in (1, 2):
         np.testing.assert_allclose(
-            net.state.layers[k].weights_in,
-            template.layers[k].weights_in - lr * mean_grads[k],
+            net.state.layers[k].weights_mean,
+            template.layers[k].weights_mean - lr * mean_grads[k],
             rtol=1e-5,
             atol=1e-6,
         )
@@ -1076,8 +1077,8 @@ def test_batch_update_averages_and_is_batch_size_invariant():
     )
     for k in (1, 2):
         np.testing.assert_allclose(
-            net_twice.state.layers[k].weights_in,
-            net.state.layers[k].weights_in,
+            net_twice.state.layers[k].weights_mean,
+            net.state.layers[k].weights_mean,
             rtol=1e-6,
             atol=1e-7,
         )
@@ -1110,14 +1111,14 @@ def test_batch_update_freezing_flags():
             np.testing.assert_array_equal(
                 getattr(elem_after.state, field), getattr(elem_before.state, field)
             )
-    assert not np.allclose(net.state.layers[1].weights_in, w1)
+    assert not np.allclose(net.state.layers[1].weights_mean, w1)
 
     # Weights frozen, precisions adapting.
     net_frozen = _ff_net(hidden_kwargs={}, top_kwargs={}, leaf_kwargs={})
     _set_weights(net_frozen, {1: w1, 2: w2})
     template_frozen = net_frozen.state
     net_frozen.batch_update(xb, yb)
-    np.testing.assert_array_equal(net_frozen.state.layers[1].weights_in, w1)
+    np.testing.assert_array_equal(net_frozen.state.layers[1].weights_mean, w1)
     assert not np.allclose(
         net_frozen.state.layers[1].state.precision,
         template_frozen.layers[1].state.precision,
@@ -1154,8 +1155,8 @@ def test_batch_update_from_predicted_states_matches():
 
     for k in (1, 2):
         np.testing.assert_allclose(
-            reused.state.layers[k].weights_in,
-            plain.state.layers[k].weights_in,
+            reused.state.layers[k].weights_mean,
+            plain.state.layers[k].weights_mean,
             rtol=1e-6,
             atol=1e-7,
         )
@@ -1242,9 +1243,9 @@ def test_input_layer_weight_gradient_sees_the_clamped_predictors():
     for flag in (False, True):
         net = _three_layer(flag)
         _set_weights(net, {1: np.eye(2, 4), 2: w})
-        before = np.asarray(net.state.layers[-1].weights_in).copy()
+        before = np.asarray(net.state.layers[-1].weights_mean).copy()
         net.prediction(x).update(y, optimizer=optax.sgd(1e-2))
-        grads.append(np.asarray(net.state.layers[-1].weights_in) - before)
+        grads.append(np.asarray(net.state.layers[-1].weights_mean) - before)
 
     # Same parent activation, same child error on this first step: same update.
     np.testing.assert_allclose(grads[0], grads[1], rtol=1e-6, atol=1e-7)
@@ -1564,8 +1565,8 @@ def test_input_layer_precision_ignores_the_constant_node():
     ``_top_precision_only`` drops the bias column before reading the routed evidence:
     the constant node is not a belief the network holds about the input, so its weights
     say nothing about how precise the observed predictors are. Its column is also what
-    makes ``weights_in`` one wider than the top layer's own precision, so leaving it in
-    would not even be shape-compatible.
+    makes ``weights_mean`` one wider than the top layer's own precision, so leaving it
+    in would not even be shape-compatible.
     """
     x, y = jnp.array([1.0, -1.0]), jnp.array([0.5, 0.5])
     rng = np.random.default_rng(11)
@@ -1624,7 +1625,7 @@ def test_fit_update_precisions_false_pins_precisions():
         )
 
     static = build()
-    before = np.asarray(static.state.layers[1].weights_in).copy()
+    before = np.asarray(static.state.layers[1].weights_mean).copy()
     static.fit(
         x,
         y,
@@ -1635,7 +1636,7 @@ def test_fit_update_precisions_false_pins_precisions():
     np.testing.assert_array_equal(
         static.state.layers[1].state.precision, jnp.full(4, 3.0)
     )
-    assert not np.allclose(np.asarray(static.state.layers[1].weights_in), before)
+    assert not np.allclose(np.asarray(static.state.layers[1].weights_mean), before)
 
     # The default carries, so the two modes genuinely diverge.
     dynamic = build().fit(x, y, optimizer=optax.sgd(1e-2), learning_kind="standard")
@@ -1697,10 +1698,12 @@ def test_optimizer_state_survives_a_fresh_optimizer_object():
         net, _, _ = _ff_net_with_weights(np.random.default_rng(31))
         sizes = []
         for _ in range(steps):
-            before = np.asarray(net.state.layers[2].weights_in).copy()
+            before = np.asarray(net.state.layers[2].weights_mean).copy()
             net.batch_update(x, y, optimizer=make_optimizer(), update_precisions=False)
             sizes.append(
-                float(np.abs(np.asarray(net.state.layers[2].weights_in) - before).max())
+                float(
+                    np.abs(np.asarray(net.state.layers[2].weights_mean) - before).max()
+                )
             )
         return net, sizes
 
@@ -1716,7 +1719,7 @@ def test_optimizer_state_survives_a_fresh_optimizer_object():
 
     # A rate change keeps the moments: the step scales with the new rate.
     net2, sizes = run(lambda: optax.adam(1e-2), steps=3)
-    before = np.asarray(net2.state.layers[2].weights_in).copy()
+    before = np.asarray(net2.state.layers[2].weights_mean).copy()
     net2.batch_update(x, y, optimizer=optax.adam(1e-1), update_precisions=False)
-    scaled = float(np.abs(np.asarray(net2.state.layers[2].weights_in) - before).max())
+    scaled = float(np.abs(np.asarray(net2.state.layers[2].weights_mean) - before).max())
     assert 8.0 < scaled / sizes[-1] < 12.0, (scaled, sizes[-1])

--- a/tests/test_eqx_types.py
+++ b/tests/test_eqx_types.py
@@ -98,7 +98,7 @@ def test_layer_static_fields_are_in_treedef_not_leaves():
     layer = Layer(
         state=LayerState.create(2),
         params=LayerParams.create(2),
-        weights_in=jnp.zeros((3, 2)),
+        weights_mean=jnp.zeros((3, 2)),
         coupling_fn=jnp.tanh,
         add_constant_input=True,
         has_volatility_parent=True,
@@ -107,7 +107,7 @@ def test_layer_static_fields_are_in_treedef_not_leaves():
         kind="volatile",
     )
     leaves = jtu.tree_leaves(layer)
-    # 13 (state) + 1 (params) + 1 (weights_in) = 15 array leaves
+    # 13 (state) + 1 (params) + 1 (weights_mean) = 15 array leaves
     assert len(leaves) == 15
     treedef_str = str(jtu.tree_structure(layer))
     # Statics show up inside the treedef, not as leaves.
@@ -116,11 +116,11 @@ def test_layer_static_fields_are_in_treedef_not_leaves():
 
 
 def test_layer_weights_in_can_be_none():
-    """The bottom layer carries weights_in=None (no child below)."""
+    """The bottom layer carries weights_mean=None (no child below)."""
     layer = Layer(
         state=LayerState.create(2),
         params=LayerParams.create(2),
-        weights_in=None,
+        weights_mean=None,
         coupling_fn=lambda x: x,
         add_constant_input=False,
         has_volatility_parent=True,
@@ -128,10 +128,10 @@ def test_layer_weights_in_can_be_none():
         fully_connected=True,
         kind="volatile",
     )
-    assert layer.weights_in is None
+    assert layer.weights_mean is None
     # tree_leaves still flattens cleanly.
     leaves = jtu.tree_leaves(layer)
-    # 13 + 1 = 14 leaves (no weights_in)
+    # 13 + 1 = 14 leaves (no weights_mean)
     assert len(leaves) == 14
 
 
@@ -140,7 +140,7 @@ def test_network_is_pytree_with_static_meta():
     layer = Layer(
         state=LayerState.create(2),
         params=LayerParams.create(2),
-        weights_in=None,
+        weights_mean=None,
         coupling_fn=jnp.tanh,
         add_constant_input=False,
         has_volatility_parent=True,
@@ -161,7 +161,7 @@ def test_network_jit_does_not_retrace_on_array_change():
     layer = Layer(
         state=LayerState.create(3),
         params=LayerParams.create(3),
-        weights_in=None,
+        weights_mean=None,
         coupling_fn=jnp.tanh,
         add_constant_input=False,
         has_volatility_parent=True,
@@ -188,7 +188,7 @@ def test_serialisation_roundtrip(tmp_path):
     layer = Layer(
         state=LayerState.create(2),
         params=LayerParams.create(2),
-        weights_in=jnp.arange(6.0).reshape(3, 2),
+        weights_mean=jnp.arange(6.0).reshape(3, 2),
         coupling_fn=jnp.tanh,
         add_constant_input=False,
         has_volatility_parent=True,
@@ -200,7 +200,7 @@ def test_serialisation_roundtrip(tmp_path):
     path = tmp_path / "net.eqx"
     eqx.tree_serialise_leaves(str(path), net)
     restored = eqx.tree_deserialise_leaves(str(path), net)
-    assert jnp.array_equal(restored.layers[0].weights_in, net.layers[0].weights_in)
+    assert jnp.array_equal(restored.layers[0].weights_mean, net.layers[0].weights_mean)
     assert restored.volatility_updates == net.volatility_updates
 
 
@@ -217,10 +217,10 @@ def test_deepnetwork_state_is_eqx_network():
     assert dn.state.n_layers == 3
     assert dn.state.get_layer_sizes() == [2, 3, 1]
     # Layer 0: no child below; layer 1 holds weights between layers 0 and 1.
-    assert dn.state.layers[0].weights_in is None
+    assert dn.state.layers[0].weights_mean is None
     assert dn.state.layers[0].is_input_layer is True
-    assert dn.state.layers[1].weights_in is not None
-    assert dn.state.layers[1].weights_in.shape == (2, 4)  # (prev_size, size + bias)
+    assert dn.state.layers[1].weights_mean is not None
+    assert dn.state.layers[1].weights_mean.shape == (2, 4)  # (prev_size, size + bias)
     # Statics propagated from the builder.
     assert dn.state.volatility_updates == "unbounded"
     assert dn.state.max_posterior_precision == 1e10
@@ -277,11 +277,11 @@ def test_deepnetwork_weights_property_legacy_shape():
         .weight_initialisation("xavier", key=jax.random.key(0))
     )
     weights = dn.state.weights
-    # Length n_layers - 1 (layer 0 has no weights_in).
+    # Length n_layers - 1 (layer 0 has no weights_mean).
     assert len(weights) == 2
-    # weights[i] == layers[i+1].weights_in.
-    np.testing.assert_array_equal(weights[0], dn.state.layers[1].weights_in)
-    np.testing.assert_array_equal(weights[1], dn.state.layers[2].weights_in)
+    # weights[i] == layers[i+1].weights_mean.
+    np.testing.assert_array_equal(weights[0], dn.state.layers[1].weights_mean)
+    np.testing.assert_array_equal(weights[1], dn.state.layers[2].weights_mean)
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +450,7 @@ def test_phase6_vmap_ensemble_run_scan_runs_n_networks_in_parallel():
     assert preds.shape == (3, 4, 2)
     # Each network's state stays distinct (the weights diverged from the
     # stacked init).
-    assert final_network.layers[1].weights_in.shape == (3, 2, 4)
+    assert final_network.layers[1].weights_mean.shape == (3, 2, 4)
 
 
 def test_phase6_to_pandas_flattens_trajectories():
@@ -497,7 +497,7 @@ def test_phase8_stack_layers_builds_consistent_pytree():
         Layer(
             state=LayerState.create(5),
             params=LayerParams.create(5),
-            weights_in=jnp.zeros((5, 6)),
+            weights_mean=jnp.zeros((5, 6)),
             coupling_fn=coupling,
             add_constant_input=True,
             has_volatility_parent=True,
@@ -511,7 +511,7 @@ def test_phase8_stack_layers_builds_consistent_pytree():
     assert isinstance(stack, LayerStack)
     assert stack.n_layers == 4
     assert stack.state.mean.shape == (4, 5)
-    assert stack.weights_in.shape == (4, 5, 6)
+    assert stack.weights_mean.shape == (4, 5, 6)
     assert stack.coupling_fn is coupling
 
 
@@ -523,7 +523,7 @@ def test_phase8_stack_layers_rejects_mismatched_statics():
     layer_a = Layer(
         state=LayerState.create(5),
         params=LayerParams.create(5),
-        weights_in=jnp.zeros((5, 6)),
+        weights_mean=jnp.zeros((5, 6)),
         coupling_fn=coupling,
         add_constant_input=True,
         has_volatility_parent=True,
@@ -564,7 +564,7 @@ def test_phase8_add_layer_stack_auto_collapses_into_layerstack():
     stack = dn.state.layers[2]
     assert isinstance(stack, LayerStack)
     assert stack.n_layers == 5
-    assert stack.weights_in.shape == (5, 6, 7)
+    assert stack.weights_mean.shape == (5, 6, 7)
 
 
 def _phase8_build(scan, depth=5, width=6, seed=0):

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -83,8 +83,8 @@ def test_fused_adapter_tracks_backprop_twin():
         w2b = w2b - lr * g_w2b
 
         fused.merge()
-        assert _norm_rel(part.net.state.layers[2].weights_in, w1b) < 1e-4, f"{step}"
-        assert _norm_rel(part.net.state.layers[1].weights_in, w2b) < 1e-4, f"{step}"
+        assert _norm_rel(part.net.state.layers[2].weights_mean, w1b) < 1e-4, f"{step}"
+        assert _norm_rel(part.net.state.layers[1].weights_mean, w2b) < 1e-4, f"{step}"
         assert _norm_rel(input_error, per_sample_dx) < 1e-2, f"step {step}"
 
 
@@ -227,14 +227,14 @@ def test_fused_merge_writes_state_back():
         from_feedforward(fc1, fc2, leaf_kwargs=_PARITY_LEAF, layer_kwargs=_PARITY),
         optimizer=optax.adam(1e-3),
     )
-    before = adapter.net.state.layers[1].weights_in
+    before = adapter.net.state.layers[1].weights_mean
     fused = FusedPipeline(adapter)
     fused.step(
         jnp.asarray(rng.normal(size=(4, 6))), jnp.asarray(rng.normal(size=(4, 6)))
     )
-    assert jnp.allclose(adapter.net.state.layers[1].weights_in, before)  # untouched
+    assert jnp.allclose(adapter.net.state.layers[1].weights_mean, before)  # untouched
     fused.merge()
-    assert not jnp.allclose(adapter.net.state.layers[1].weights_in, before)
+    assert not jnp.allclose(adapter.net.state.layers[1].weights_mean, before)
     assert adapter.net.opt_state is fused.state[1]
 
 

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -93,8 +93,8 @@ def _parity_ff_net(d: int, h: int, w1: jnp.ndarray, w2: jnp.ndarray) -> DeepNetw
         .add_layer(size=d, add_constant_input=False, **high_precision)
     )
     elements = list(net.state.layers)
-    elements[1] = dataclasses.replace(elements[1], weights_in=w1)
-    elements[2] = dataclasses.replace(elements[2], weights_in=w2)
+    elements[1] = dataclasses.replace(elements[1], weights_mean=w1)
+    elements[2] = dataclasses.replace(elements[2], weights_mean=w2)
     net.state = dataclasses.replace(net.state, layers=tuple(elements))
     return net
 
@@ -160,8 +160,8 @@ def test_mixed_pipeline_block_matches_backprop():
         return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
 
     # (b) The weights moved by the batch-averaged backprop gradient.
-    d_w1 = -(ff.net.state.layers[1].weights_in - w1) / lr
-    d_w2 = -(ff.net.state.layers[2].weights_in - w2) / lr
+    d_w1 = -(ff.net.state.layers[1].weights_mean - w1) / lr
+    d_w2 = -(ff.net.state.layers[2].weights_mean - w2) / lr
     assert norm_rel(d_w1, g_w1) < 1e-2
     assert norm_rel(d_w2, g_w2) < 1e-2
     # (c) The emitted input error is the loss gradient at the input.

--- a/tests/test_rs_deepnetwork.py
+++ b/tests/test_rs_deepnetwork.py
@@ -94,7 +94,7 @@ def _inject_jax_weights(net, weights):
     """Write the given weight matrices into the JAX network's layers 1..n."""
     layers = list(net.state.layers)
     new_layers = [layers[0]] + [
-        dataclasses.replace(layer, weights_in=jnp.asarray(w))
+        dataclasses.replace(layer, weights_mean=jnp.asarray(w))
         for layer, w in zip(layers[1:], weights)
     ]
     net.state = dataclasses.replace(net.state, layers=tuple(new_layers))
@@ -390,7 +390,7 @@ def test_fit_trajectory_parity(optimizer, make_optax):
     jx.fit(x, y, make_optax())
 
     np.testing.assert_allclose(preds_rs, np.asarray(jx.predictions), **TRAJECTORY)
-    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    jx_weights = [np.asarray(layer.weights_mean) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 
@@ -457,7 +457,7 @@ def test_fit_parity_binary_output():
     preds_rs = rs.fit(x, y, optimizer="sgd", learning_rate=0.05)
     jx.fit(x, y, optax.sgd(0.05))
     np.testing.assert_allclose(preds_rs, np.asarray(jx.predictions), **TRAJECTORY)
-    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    jx_weights = [np.asarray(layer.weights_mean) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 
@@ -513,7 +513,7 @@ def test_batch_update_trajectory_parity(optimizer):
         )
         jx.batch_update(x, y, optimizer=optax_opt)
         np.testing.assert_allclose(errors_rs, np.asarray(jx.input_errors), **TRAJECTORY)
-    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    jx_weights = [np.asarray(layer.weights_mean) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 
@@ -534,7 +534,7 @@ def test_batch_update_parity_pinned_precisions():
         )
         jx.batch_update(x, y, optimizer=optax.sgd(0.05), update_precisions=False)
     np.testing.assert_allclose(errors_rs, np.asarray(jx.input_errors), **TRAJECTORY)
-    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    jx_weights = [np.asarray(layer.weights_mean) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 
@@ -572,7 +572,7 @@ def test_batch_update_parity_categorical_output():
         errors_rs = rs.batch_update(x, y, optimizer="adam", learning_rate=1e-2)
         jx.batch_update(x, y, optimizer=optax_opt)
     np.testing.assert_allclose(errors_rs, np.asarray(jx.input_errors), **TRAJECTORY)
-    jx_weights = [np.asarray(layer.weights_in) for layer in jx.state.layers[1:]]
+    jx_weights = [np.asarray(layer.weights_mean) for layer in jx.state.layers[1:]]
     for w_rs, w_jx in zip(rs.get_weights(), jx_weights):
         np.testing.assert_allclose(w_rs, w_jx, **TRAJECTORY)
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -305,10 +305,10 @@ def test_fused_qkv_through_hybrid_and_merge():
     reference = jax.vmap(gpt)(ids)
     np.testing.assert_allclose(pipeline.predict(ids), reference, rtol=1e-4, atol=1e-5)
 
-    before = np.asarray(qkv_parts[0].net.state.layers[1].weights_in)
+    before = np.asarray(qkv_parts[0].net.state.layers[1].weights_mean)
     pipeline.step(ids, targets)
     pipeline.merge()
-    after = np.asarray(qkv_parts[0].net.state.layers[1].weights_in)
+    after = np.asarray(qkv_parts[0].net.state.layers[1].weights_mean)
     assert not np.allclose(before, after)  # the fused weights learnt
 
 
@@ -397,8 +397,8 @@ def test_ff_swap_matches_backprop():
             [grads.blocks[i].ff.fc1.weight, grads.blocks[i].ff.fc1.bias[:, None]],
             axis=1,
         )
-        d_fc2 = -(net.state.layers[1].weights_in - w1b) / lr
-        d_fc1 = -(net.state.layers[2].weights_in - w2b) / lr
+        d_fc2 = -(net.state.layers[1].weights_mean - w1b) / lr
+        d_fc1 = -(net.state.layers[2].weights_mean - w2b) / lr
         assert _norm_rel(d_fc2, g_fc2) < 1e-2, f"block {i}, hidden→output"
         assert _norm_rel(d_fc1, g_fc1) < 1e-2, f"block {i}, input→hidden"
 
@@ -489,7 +489,7 @@ def test_full_pyhgf_gpt_matches_backprop():
     fused.merge()
 
     def delta(part, layer_index, reference):
-        return -(part.net.state.layers[layer_index].weights_in - reference) / lr
+        return -(part.net.state.layers[layer_index].weights_mean - reference) / lr
 
     # Attention tables and the head (no biases).
     for i, block in enumerate(gpt.blocks):
@@ -575,7 +575,7 @@ def test_binary_head_at_vocabulary_width():
 
     # (c) Weight update: the plain sigmoid-cross-entropy gradient.
     expected_grad = ((probs - one_hot)[..., None] * x[:, None, :]).mean(axis=0)
-    d_w = -(net.state.layers[1].weights_in - head.weight) / lr
+    d_w = -(net.state.layers[1].weights_mean - head.weight) / lr
     assert _norm_rel(d_w, expected_grad) < 1e-2
 
 
@@ -623,7 +623,7 @@ def test_categorical_head_matches_softmax_backprop():
     g_w, g_x = jax.grad(lambda w, x_: loss(w, x_), argnums=(0, 1))(head.weight, x)
 
     # (b) Weight update: the plain cross-entropy gradient.
-    d_w = -(net.state.layers[1].weights_in - head.weight) / lr
+    d_w = -(net.state.layers[1].weights_mean - head.weight) / lr
     assert _norm_rel(d_w, g_w) < 1e-2
     # (c) Input message: PyHGF errors are observed-minus-predicted — the
     # negative of the loss gradient at the input. The oracle's mean over the
@@ -706,7 +706,7 @@ def test_full_pyhgf_gpt_with_categorical_head():
     fused.merge()
 
     def delta(part, layer_index, reference):
-        return -(part.net.state.layers[layer_index].weights_in - reference) / lr
+        return -(part.net.state.layers[layer_index].weights_mean - reference) / lr
 
     d_head = delta(head_part, 1, gpt.head.weight)
     assert _norm_rel(d_head, grads.head.weight) < 2e-2, "categorical head"

--- a/tests/test_transplant.py
+++ b/tests/test_transplant.py
@@ -112,8 +112,8 @@ def test_transplanted_feedforward_learns_like_backprop_with_biases():
     def norm_rel(a, b):
         return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
 
-    d_w2b = -(net.state.layers[1].weights_in - w2b) / lr  # hidden→output block
-    d_w1b = -(net.state.layers[2].weights_in - w1b) / lr  # input→hidden block
+    d_w2b = -(net.state.layers[1].weights_mean - w2b) / lr  # hidden→output block
+    d_w1b = -(net.state.layers[2].weights_mean - w1b) / lr  # input→hidden block
     assert norm_rel(d_w1b, g_w1b) < 1e-2
     assert norm_rel(d_w2b, g_w2b) < 1e-2
     # PyHGF errors are observed-minus-predicted: the negative of the loss

--- a/tests/test_vectorized_continuous.py
+++ b/tests/test_vectorized_continuous.py
@@ -442,10 +442,10 @@ def test_coupling_fan_in_normalisation():
         .add_layer(2, kind="continuous", value_coupling=0.6)
         .add_layer(4, kind="continuous", volatility_children=1, volatility_coupling=0.8)
     )
-    weights = dense.state.layers[1].weights_in
+    weights = dense.state.layers[1].weights_mean
     assert weights.shape == (2, 2)
     assert jnp.allclose(weights, 0.6 / 2)
-    kappa = dense.state.layers[2].volatility_weights_in
+    kappa = dense.state.layers[2].volatility_weights
     assert kappa.shape == (2, 4)
     assert jnp.allclose(kappa, 0.8 / 4)
 
@@ -461,7 +461,7 @@ def test_coupling_fan_in_normalisation():
             volatility_fully_connected=False,
         )
     )
-    kappa = one_to_one.state.layers[2].volatility_weights_in
+    kappa = one_to_one.state.layers[2].volatility_weights
     assert jnp.allclose(kappa, 0.8 * jnp.eye(2))
 
 

--- a/tests/test_weight_belief.py
+++ b/tests/test_weight_belief.py
@@ -1,0 +1,528 @@
+# Author: Nicolas Legrand <nicolas.legrand@cas.au.dk>
+
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+
+from pyhgf.model import DeepNetwork
+from pyhgf.typing.vectorised import LayerState
+from pyhgf.updates.vectorized.learning import (
+    learning_weights_vectorized,
+    resolve_synaptic_uncertainty_settings,
+    vectorized_synaptic_uncertainty_update,
+)
+
+
+def _importance(parent_state, child_state, coupling_fn, **kwargs):
+    """Return the importance factors ``(p, h**2)`` through the module's entry point.
+
+    The entry point hands back the shared parent-side activation; the importance's own
+    parent factor is its square.
+    """
+    _, h, p = learning_weights_vectorized(
+        parent_state, child_state, coupling_fn, **kwargs
+    )
+    return p, h**2
+
+
+def _states(parent_mean, child_precision):
+    """Parent and child LayerStates carrying the given evidence precision.
+
+    The child's evidence precision is its posterior minus its marginal predicted
+    precision, so the posterior is set to the requested value above a unit prediction.
+    Zero effective precision means no process noise, so the evidence reaches the weight
+    unsoftened and equals ``child_precision``.
+    """
+    parent = dataclasses.replace(
+        LayerState.create(len(parent_mean), has_volatility_parent=False),
+        mean=jnp.asarray(parent_mean),
+    )
+    child = dataclasses.replace(
+        LayerState.create(len(child_precision), has_volatility_parent=False),
+        expected_precision=jnp.ones(len(child_precision)),
+        precision=jnp.asarray(child_precision) + 1.0,
+        effective_precision=jnp.zeros(len(child_precision)),
+    )
+    return parent, child
+
+
+def test_effective_evidence_precision():
+    """The evidence precision is recovered from the sweeps' cached fields.
+
+    Read through the entry point's importance factor, which is where the quantity now
+    lives.
+    """
+    n = 3
+    base = LayerState.create(n, has_volatility_parent=False)
+    parent = dataclasses.replace(
+        LayerState.create(2, has_volatility_parent=False), mean=jnp.ones(2)
+    )
+
+    def xi_tilde(child):
+        _, _, p = learning_weights_vectorized(parent, child, lambda m: m)
+        return p
+
+    # Evidence is posterior minus marginal predicted; with no process noise it
+    # reaches the weight unsoftened.
+    state = dataclasses.replace(
+        base,
+        expected_precision=jnp.array([1.0, 2.0, 0.5]),
+        precision=jnp.array([5.0, 6.0, 2.5]),
+        effective_precision=jnp.zeros(n),
+    )
+    np.testing.assert_allclose(xi_tilde(state), [4.0, 4.0, 2.0], rtol=1e-6)
+
+    # Process noise adds to the evidence *variance*: with omega = gamma / pi
+    # tilde, xi_tilde = xi / (1 + omega xi). Here omega = 0.25 throughout.
+    state = dataclasses.replace(
+        base,
+        expected_precision=jnp.array([1.0, 2.0, 0.5]),
+        precision=jnp.array([5.0, 6.0, 2.5]),
+        effective_precision=0.25 * jnp.array([1.0, 2.0, 0.5]),
+    )
+    xi = np.array([4.0, 4.0, 2.0])
+    np.testing.assert_allclose(xi_tilde(state), xi / (1.0 + 0.25 * xi), rtol=1e-6)
+
+    # A clamped observed layer has its marginal predicted precision forced to
+    # its posterior, so no evidence arrives and its own precision stands in.
+    clamped = dataclasses.replace(
+        base,
+        expected_precision=jnp.array([3.0, 3.0, 3.0]),
+        precision=jnp.array([3.0, 3.0, 3.0]),
+        effective_precision=jnp.zeros(n),
+    )
+    np.testing.assert_allclose(xi_tilde(clamped), [3.0] * 3)
+
+    # Clipping can drive the posterior below the prediction; the increment must
+    # stay non-negative rather than turning into a precision subtraction.
+    clipped = dataclasses.replace(
+        base,
+        expected_precision=jnp.array([4.0, 4.0, 4.0]),
+        precision=jnp.array([1.0, 1.0, 1.0]),
+        effective_precision=jnp.zeros(n),
+    )
+    assert np.all(np.asarray(xi_tilde(clipped)) >= 0.0)
+
+
+def _step(weights, precision_delta, gradient, importance, **kwargs):
+    """One belief step, returning ``(update, new_delta)``.
+
+    The rule returns the new mean; the tests below are written against the *change* in
+    the mean, which is what the update rule states.
+    """
+    settings = resolve_synaptic_uncertainty_settings(kwargs)
+    new_weights, new_delta = vectorized_synaptic_uncertainty_update(
+        weights, precision_delta, gradient, importance, settings
+    )
+    return new_weights - weights, new_delta
+
+
+def test_importance_factors_kernel():
+    """The importance kernel returns (evidence precision, h^2)."""
+    parent, child = _states([0.5, -2.0, 3.0], [4.0, 0.25])
+    identity = lambda m: m  # noqa: E731
+
+    p, q = _importance(parent, child, identity)
+    np.testing.assert_allclose(p, [4.0, 0.25])
+    np.testing.assert_allclose(q, [0.25, 4.0, 9.0])
+
+    # Constant input appends a unit activation, so the bias weight counts as usage 1.
+    p, q = _importance(parent, child, identity, parent_has_constant=True)
+    np.testing.assert_allclose(q, [0.25, 4.0, 9.0, 1.0])
+
+    # A clamped discrete child contributes the curvature of its own likelihood,
+    # p(1 - p), read off its expected mean rather than any precision field.
+    probs = jnp.array([0.25, 0.9])
+    discrete = dataclasses.replace(child, expected_mean=probs)
+    for child_kind in ("binary", "categorical"):
+        p, _ = _importance(parent, discrete, identity, child_kind=child_kind)
+        np.testing.assert_allclose(p, probs * (1.0 - probs), rtol=1e-6)
+
+    # The "standard" kind keeps the unit-precision convention throughout.
+    p, _ = _importance(parent, child, identity, kind="standard")
+    np.testing.assert_allclose(p, [1.0, 1.0])
+    p, _ = _importance(parent, discrete, identity, kind="standard", child_kind="binary")
+    np.testing.assert_allclose(p, [1.0, 1.0])
+
+    # A nonlinear coupling squares the coupled activation, not the raw mean.
+    p, q = _importance(parent, child, jnp.tanh)
+    np.testing.assert_allclose(q, np.tanh([0.5, -2.0, 3.0]) ** 2, rtol=1e-6)
+
+    # Non-finite entries are zeroed rather than propagated.
+    bad_parent = dataclasses.replace(parent, mean=jnp.array([jnp.inf, 1.0, 2.0]))
+    _, q = _importance(bad_parent, child, identity)
+    np.testing.assert_allclose(q, [0.0, 1.0, 4.0])
+
+    with pytest.raises(ValueError):
+        _importance(parent, child, identity, kind="nope")
+
+
+def test_settings_validation():
+    """Invalid configurations are rejected when the settings are resolved."""
+    with pytest.raises(ValueError, match="window"):
+        resolve_synaptic_uncertainty_settings({})
+    with pytest.raises(ValueError, match="at least 1"):
+        resolve_synaptic_uncertainty_settings({"window": 0.5})
+    with pytest.raises(ValueError, match="learning_rate"):
+        resolve_synaptic_uncertainty_settings({"window": 100, "learning_rate": 0.0})
+    with pytest.raises(ValueError, match="increment_scale"):
+        resolve_synaptic_uncertainty_settings({"window": 100, "increment_scale": 0.0})
+    with pytest.raises(ValueError, match="Unknown learning_kwargs"):
+        resolve_synaptic_uncertainty_settings({"window": 100, "nonsense": 1})
+
+    # The gradient the rule descends is fixed, so it is not a setting: even the
+    # value it is fixed to is rejected as an unknown key.
+    with pytest.raises(ValueError, match="Unknown learning_kwargs"):
+        resolve_synaptic_uncertainty_settings({
+            "window": 100,
+            "kind": "synaptic_uncertainty",
+        })
+
+    # The leak and update form are no longer settings, so naming either is an
+    # unknown key rather than a choice.
+    for gone in ("leak", "update_form", "autoconnection", "tonic_variance"):
+        with pytest.raises(ValueError, match="Unknown learning_kwargs"):
+            resolve_synaptic_uncertainty_settings({
+                "window": 100,
+                gone: "synaptic_uncertainty",
+            })
+
+
+def test_sgd_reduction_at_init():
+    """With no accumulated importance the rule is plain SGD at prior_variance.
+
+    The only departure is the mean reversion toward prior_mean, at rate 1/window when
+    the precision sits at the prior.
+    """
+    window, prior_variance = 1000.0, 0.3
+    w = jnp.array([[0.5, -1.0, 2.0], [0.0, 0.1, -0.2]])
+    g = jnp.array([[1.0, -2.0, 0.5], [0.3, 0.0, -1.5]])
+    precision_delta = jnp.zeros_like(w)
+
+    # Compared on the mean the rule returns rather than on a difference: where
+    # the step is small next to the weight, recovering it by subtraction costs
+    # more float32 accuracy than the step itself carries.
+    settings = resolve_synaptic_uncertainty_settings({
+        "window": window,
+        "prior_variance": prior_variance,
+    })
+    new_weights, new_delta = vectorized_synaptic_uncertainty_update(
+        w, precision_delta, g, (jnp.zeros(2), jnp.zeros(3)), settings
+    )
+    np.testing.assert_allclose(
+        new_weights, w + (-prior_variance * g - w / window), rtol=1e-5
+    )
+    # Zero increment leaves the precision at the prior, i.e. no accumulation at
+    # all. Asserted on the delta itself: adding the prior back first would apply
+    # the tolerance to a base of 1 / prior_variance and accept a small non-zero
+    # accumulation.
+    np.testing.assert_allclose(new_delta, 0.0, atol=1e-12)
+
+
+def test_learning_rate_scales_steps_but_not_forgetting():
+    """The multiplier scales the gradient step and leaves the leak alone.
+
+    Doubling it doubles the gradient part of the update, leaves the reversion toward the
+    prior untouched, and does not touch the precision at all, so the depth of protection
+    and the forgetting window are unchanged.
+    """
+    window, prior_variance = 500.0, 0.1
+    w = jnp.array([[0.4, -0.7]])
+    g = jnp.array([[1.0, -0.5]])
+    precision_delta = jnp.zeros_like(w)
+    importance = (jnp.array([1.5]), jnp.array([0.5, 2.0]))
+
+    updates, deltas = {}, {}
+    for alpha in (1.0, 2.0):
+        updates[alpha], deltas[alpha] = _step(
+            w,
+            precision_delta,
+            g,
+            importance,
+            window=window,
+            prior_variance=prior_variance,
+            learning_rate=alpha,
+        )
+
+    reversion = -w / window  # prior mean 0, precision at its prior value
+    gradient_part = {a: updates[a] - reversion for a in (1.0, 2.0)}
+    np.testing.assert_allclose(gradient_part[2.0], 2.0 * gradient_part[1.0], rtol=1e-6)
+    np.testing.assert_allclose(deltas[2.0], deltas[1.0], rtol=1e-9)
+
+
+def test_increment_scale_deepens_protection_only():
+    """The scale multiplies the precision gain and leaves the first step alone.
+
+    Under the rule's leak the mean update divides by the pre-update precision, so at the
+    prior the first step is identical at any scale; the precision gain is multiplied
+    exactly.
+    """
+    w = jnp.zeros((1, 2))
+    g = jnp.array([[1.0, -0.5]])
+    precision_delta = jnp.zeros_like(w)
+    importance = (jnp.array([2.0]), jnp.array([0.5, 1.5]))
+
+    results = {}
+    for scale in (1.0, 30.0):
+        results[scale] = _step(
+            w,
+            precision_delta,
+            g,
+            importance,
+            window=1000.0,
+            prior_variance=0.5,
+            increment_scale=scale,
+        )
+
+    np.testing.assert_allclose(results[30.0][0], results[1.0][0], rtol=1e-6)
+    np.testing.assert_allclose(results[30.0][1], 30.0 * results[1.0][1], rtol=1e-6)
+
+
+def test_synaptic_uncertainty_fixed_point_is_linear_in_evidence():
+    """Under the rule's leak the precision converges to prior + window * increment."""
+    window, prior_variance = 50.0, 1.0
+    settings = resolve_synaptic_uncertainty_settings({
+        "window": window,
+        "prior_variance": prior_variance,
+    })
+    w = jnp.zeros((1, 2))
+    precision_delta = jnp.zeros_like(w)
+    p, q = jnp.array([2.0]), jnp.array([0.5, 1.5])
+    g = jnp.zeros((1, 2))
+    for _ in range(2000):
+        w, precision_delta = vectorized_synaptic_uncertainty_update(
+            w, precision_delta, g, (p, q), settings
+        )
+
+    expected = 1.0 / prior_variance + window * p[0] * q
+    np.testing.assert_allclose(
+        precision_delta[0] + 1.0 / prior_variance, expected, rtol=1e-3
+    )
+
+
+def test_layer_stack_shapes():
+    """Stacked elements (leading slice axis) broadcast through the update."""
+    w = jnp.zeros((4, 2, 3))  # (n_slices, n_children, n_parents)
+    precision_delta = jnp.zeros_like(w)
+    g = jnp.ones((4, 2, 3))
+    importance = (jnp.ones((4, 2)), jnp.ones((4, 3)))
+
+    update, new_delta = _step(
+        w, precision_delta, g, importance, window=100.0, prior_variance=1.0
+    )
+    assert update.shape == (4, 2, 3)
+    assert new_delta.shape == (4, 2, 3)
+    assert bool(jnp.all(new_delta + 1.0 > 1.0))
+
+
+def test_synaptic_uncertainty_matches_the_increment_it_divides():
+    """The rule's gradient and its increment are one energy's two derivatives.
+
+    The weight-belief step is (gradient / accumulated precision), so the two have to be
+    built from the same evidence or the ratio is not a Newton step. The gradient's
+    child-side factor is the posterior precision softened by the process noise; the
+    increment's is the evidence precision softened by the same noise. Their ratio must
+    therefore be the posterior precision over the evidence precision, with no leftover
+    noise term.
+    """
+    n = 3
+    base = LayerState.create(n, has_volatility_parent=False)
+    state = dataclasses.replace(
+        base,
+        mean=jnp.array([1.0, -2.0, 0.5]),
+        expected_mean=jnp.zeros(n),
+        expected_precision=jnp.array([1.0, 2.0, 0.5]),
+        precision=jnp.array([5.0, 6.0, 2.5]),
+        effective_precision=0.25 * jnp.array([1.0, 2.0, 0.5]),
+    )
+    parent = dataclasses.replace(
+        LayerState.create(2, has_volatility_parent=False), mean=jnp.array([1.0, -1.0])
+    )
+    identity = lambda m: m  # noqa: E731
+
+    u_ev, _, _ = learning_weights_vectorized(
+        parent, state, identity, kind="synaptic_uncertainty"
+    )
+    u_pw, _, _ = learning_weights_vectorized(
+        parent, state, identity, kind="precision_weighted"
+    )
+    _, _, p_inc = learning_weights_vectorized(
+        parent, state, identity, kind="synaptic_uncertainty"
+    )
+
+    evidence = np.asarray(state.precision - state.expected_precision)
+    softening = 1.0 / (1.0 + 0.25 * evidence)
+    # The gradient is the precision-weighted one charged the process noise.
+    np.testing.assert_allclose(u_ev, np.asarray(u_pw) * softening, rtol=1e-6)
+    # Ratio of the two child-side factors: posterior over evidence precision,
+    # the softening having cancelled.
+    np.testing.assert_allclose(
+        np.asarray(u_ev) / np.asarray(p_inc),
+        -np.asarray(state.mean) * np.asarray(state.precision) / evidence,
+        rtol=1e-6,
+    )
+
+    # Where there is no process noise the two precision kinds coincide.
+    quiet = dataclasses.replace(state, effective_precision=jnp.zeros(n))
+    np.testing.assert_allclose(
+        learning_weights_vectorized(
+            parent, quiet, identity, kind="synaptic_uncertainty"
+        )[0],
+        learning_weights_vectorized(parent, quiet, identity, kind="precision_weighted")[
+            0
+        ],
+        rtol=1e-9,
+    )
+
+
+def test_gradient_kind_is_pinned():
+    """The rule descends one gradient, whatever the network was built around.
+
+    The mean update divides the child's evidence by the weight's own precision,
+    so the numerator has to carry that evidence: the precision-weighted form is
+    the only one that does. A network whose plain learning kind is "standard"
+    still gets the pinned gradient once the belief rule is selected.
+    """
+    dn = DeepNetwork().add_layer(size=2).add_layer(size=3)
+
+    gradient_kind, settings = dn._resolve_learning(
+        "synaptic_uncertainty", {"window": 100.0}
+    )
+    assert gradient_kind == "synaptic_uncertainty"
+    assert not hasattr(settings, "kind")
+
+    # A plain kind still passes through untouched, carrying no settings.
+    assert dn._resolve_learning("standard", None) == ("standard", None)
+
+
+def test_deepnetwork_integration():
+    """Both learning paths carry the belief on the layers, not beside them.
+
+    The sequential (fit) and batch-synchronous (batch_update) paths accumulate precision
+    above the prior on the elements that hold weights, need no optimiser, and leave
+    plain optax members working unchanged.
+    """
+    n_targets, n_h, n_input = 2, 3, 1
+    np.random.seed(7)
+    x = np.random.randn(8, n_input)
+    y = np.random.randn(8, n_targets)
+    kwargs = {"window": 100.0, "prior_variance": 0.1}
+
+    def build():
+        return (
+            DeepNetwork()
+            .add_layer(size=n_targets)
+            .add_layer(size=n_h)
+            .add_layer(size=n_input)
+            .weight_initialisation("xavier", key=jax.random.key(0))
+        )
+
+    # Sequential path: the belief is installed on first use and no optimiser
+    # state is created, since the rule carries its own step size.
+    dn = build()
+    dn.fit(x=x, y=y, learning_kind="synaptic_uncertainty", learning_kwargs=kwargs)
+    assert dn.opt_state is None
+    accumulated = [
+        e
+        for e in (
+            getattr(elem, "weights_precision_delta", None) for elem in dn.state.layers
+        )
+        if e is not None
+    ]
+    assert len(accumulated) == 2
+    assert all(bool(jnp.all(jnp.isfinite(e))) for e in accumulated)
+    assert any(bool(jnp.any(e > 1e-6)) for e in accumulated)
+    # One precision per weight: the belief sits on exactly the elements holding a
+    # weight matrix, matches its shape, and only ever accumulates above the prior,
+    # which the field stores as the delta over it.
+    for elem in dn.state.layers:
+        precision_delta = getattr(elem, "weights_precision_delta", None)
+        assert (precision_delta is None) == (elem.weights_mean is None)
+        if precision_delta is not None:
+            assert precision_delta.shape == elem.weights_mean.shape
+            assert bool(jnp.all(precision_delta >= 0.0))
+    assert bool(jnp.all(jnp.isfinite(dn.predict(np.array([[0.5]])))))
+
+    # Batched path.
+    dn_batch = build()
+    dn_batch.batch_update(
+        x, y, learning_kind="synaptic_uncertainty", learning_kwargs=kwargs
+    )
+    accumulated = [
+        e
+        for e in (
+            getattr(elem, "weights_precision_delta", None)
+            for elem in dn_batch.state.layers
+        )
+        if e is not None
+    ]
+    assert any(bool(jnp.any(e > 1e-6)) for e in accumulated)
+
+    # Plain optax path is untouched, and carries no belief.
+    dn_sgd = build()
+    dn_sgd.fit(x=x, y=y, optimizer=optax.sgd(0.1))
+    assert all(
+        e is None
+        for e in (
+            getattr(elem, "weights_precision_delta", None)
+            for elem in dn_sgd.state.layers
+        )
+    )
+    assert bool(jnp.all(jnp.isfinite(dn_sgd.predict(np.array([[0.5]])))))
+
+    # A gradient kind without an optimiser is refused rather than silently idle.
+    with pytest.raises(ValueError, match="needs an optimizer"):
+        build().fit(x=x, y=y)
+    # learning_kwargs is only meaningful for the belief rule.
+    with pytest.raises(ValueError, match="only used by"):
+        build().fit(x=x, y=y, optimizer=optax.sgd(0.1), learning_kwargs=kwargs)
+
+
+def test_install_weight_belief_is_explicit_and_idempotent():
+    """The belief can be installed ahead of the first fit, and only once."""
+    net = (
+        DeepNetwork()
+        .add_layer(size=2)
+        .add_layer(size=3)
+        .weight_initialisation("xavier", key=jax.random.key(0))
+    )
+    assert all(
+        e is None
+        for e in (
+            getattr(elem, "weights_precision_delta", None) for elem in net.state.layers
+        )
+    )
+
+    net.install_weight_belief()
+    precision_delta = tuple(
+        getattr(elem, "weights_precision_delta", None) for elem in net.state.layers
+    )
+    assert precision_delta[0] is None  # the bottom layer holds no weights
+    np.testing.assert_allclose(precision_delta[1], 0.0)
+    assert precision_delta[1].shape == net.state.layers[1].weights_mean.shape
+
+    # Installing again leaves an accumulated belief alone.
+    net.state = dataclasses.replace(
+        net.state,
+        layers=(
+            net.state.layers[0],
+            dataclasses.replace(
+                net.state.layers[1],
+                weights_precision_delta=jnp.full_like(precision_delta[1], 2.5),
+            ),
+        ),
+    )
+    net.install_weight_belief()
+    np.testing.assert_allclose(
+        tuple(
+            getattr(elem, "weights_precision_delta", None) for elem in net.state.layers
+        )[1],
+        2.5,
+    )
+
+    with pytest.raises(ValueError, match="hold no weight matrix"):
+        net.install_weight_belief(layers=[0])

--- a/tests/test_weight_gradient.py
+++ b/tests/test_weight_gradient.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import pytest
 
 from pyhgf.typing.vectorised import LayerState
-from pyhgf.updates.vectorized.learning import vectorized_weight_gradient
+from pyhgf.updates.vectorized.learning import learning_weights_vectorized
 
 
 @pytest.fixture(autouse=True)
@@ -59,9 +59,10 @@ def test_precision_weighted_uses_posterior_precision():
     pi_pred = jnp.exp(jax.random.normal(k[5], (d_c,)))  # predicted (expected)
     parent = _state(a, pi_p, a, pi_p)
     child = _state(x, pi_post, xhat, pi_pred)  # distinct posterior vs predicted
-    got = vectorized_weight_gradient(
+    u, h, _ = learning_weights_vectorized(
         parent, child, lambda z: z, kind="precision_weighted"
     )
+    got = u[:, None] * h[None, :]
     ref = -((x - xhat) * pi_post)[:, None] * a[None, :]  # descent, posterior precision
     assert jnp.allclose(got, ref, atol=1e-12)
     wrong = -((x - xhat) * pi_pred)[:, None] * a[None, :]


### PR DESCRIPTION
Gives every weight a Gaussian belief instead of a bare number, and adds the update rule that carries it. The weight itself is the belief's mean; the new `weights_precision_delta` field on `Layer` holds its precision above the prior.

`learning_kind="synaptic_uncertainty"` runs the rule inside the belief sweep and takes no optimiser — the step size is the belief's own. The mean update is the incoming descent gradient divided by the weight's precision, plus a precision-scaled pull toward `prior_mean`; the precision update adds the curvature the data impose and relaxes toward the prior at rate `1/window`. Settings arrive through `learning_kwargs` and are validated by `resolve_mesu_settings`, which requires `window` and rejects unknown keys. At the start, the precision is the prior everywhere, so the rule begins as plain gradient descent at rate `learning_rate × prior_variance` and departs from it only as curvature accumulates. Both halves are mean-field: the joint structure across the weights feeding one child is not retained.
