### PR TITLE
Fix the curvature `synaptic_uncertainty` accumulates above the observed layer

### DIFF
--- a/pyhgf/updates/vectorized/learning.py
+++ b/pyhgf/updates/vectorized/learning.py
@@ -6,6 +6,8 @@
 from typing import Callable, NamedTuple, Optional, Union
 
 import jax.numpy as jnp
+from jax import grad as jgrad
+from jax import vmap
 
 from pyhgf.typing.vectorised import LayerState
 
@@ -25,6 +27,7 @@ def learning_weights_vectorized(
     kind: str = "precision_weighted",
     parent_has_constant: bool = False,
     child_kind: str = "continuous",
+    child_evidence: Optional[jnp.ndarray] = None,
 ) -> tuple:
     r"""Per-layer weight-learning factors for the vectorised deep network.
 
@@ -93,19 +96,23 @@ def learning_weights_vectorized(
       observed errors.
     - A **continuous** child passes on the evidence it received from below,
       softened by the process noise it had to cross,
-      :math:`\tilde\xi_a = (1/\xi_a + \Omega_a)^{-1}`. Both parts are already
-      cached by the sweeps: :math:`\xi_a = \pi_a - \tilde\pi_a`, the posterior
-      precision minus the marginal predicted precision, because a Gaussian
-      posterior precision is its prior plus its likelihood; and
-      :math:`\Omega_a = \gamma_a / \tilde\pi_a`, recovered from the effective
+      :math:`\tilde\xi_a = (1/\xi_a + \Omega_a)^{-1}`, with
+      :math:`\Omega_a = \gamma_a / \tilde\pi_a` recovered from the effective
       precision the prediction sweep writes as
-      :math:`\gamma_a = \Omega_a \tilde\pi_a`. Softening by :math:`\Omega_a`
-      alone is what distinguishes this from the conditional predicted
-      precision :math:`\hat\pi_a`, which softens by
-      :math:`1/\pi_a^{\text{prev}} + \Omega_a` and so also carries the node's
-      own prior variance from the previous step: information about the same
-      quantity for a time series, but about a *different* sample's activation
-      for exchangeable samples.
+      :math:`\gamma_a = \Omega_a \tilde\pi_a`. The evidence :math:`\xi_a`
+      itself is supplied by the caller through *child_evidence*, carried up from
+      the clamped layer by :func:`evidence_pullback`, and the weight-belief rule
+      always supplies it.
+
+      Without it, :math:`\xi_a` falls back to :math:`\pi_a - \tilde\pi_a` from
+      the cache, which is the same quantity in exact arithmetic *only* where the
+      filter's own precision chain was seeded with the clamped layer's likelihood
+      curvature. It is not: a clamped categorical layer enters that chain at unit
+      precision, because that convention is what makes the message it routes exact
+      cross-entropy backpropagation. Reading the difference also subtracts two
+      large nearly-equal precisions, which loses every significant digit once a
+      layer's precision has accumulated. The fallback is kept for direct callers
+      reading the layer-local quantity; it is not what the rule descends.
 
     Parameters
     ----------
@@ -126,6 +133,15 @@ def learning_weights_vectorized(
     child_kind :
         The child layer's node kind, ``"binary"``, ``"categorical"`` or
         anything else for a continuous one.
+    child_evidence :
+        The child's evidence precision :math:`\xi_a`, supplied by a caller that
+        carries it up the stack itself (:func:`evidence_pullback`) rather than
+        letting it be recovered here as :math:`\pi_a - \tilde\pi_a`. When given,
+        it replaces that difference in the importance factor and the fallback
+        below never applies, since a carried evidence is non-negative by
+        construction. The gradient factor is unaffected: it reads the child's
+        posterior precision either way. ``None`` (default) recovers the evidence
+        from the cache.
 
     Returns
     -------
@@ -159,7 +175,10 @@ def learning_weights_vectorized(
     # of the update read these, so they are formed once. The evidence is
     # floored at zero: clipping can drive a posterior precision below its
     # prediction, which must not turn the increment into a subtraction.
-    evidence = child_state.precision - child_state.expected_precision
+    if child_evidence is None:
+        evidence = child_state.precision - child_state.expected_precision
+    else:
+        evidence = child_evidence
     floored = jnp.maximum(evidence, 0.0)
     tonic = child_state.effective_precision / jnp.maximum(
         child_state.expected_precision, _EPS
@@ -182,6 +201,11 @@ def learning_weights_vectorized(
     # elimination, so gating them on a flag would buy nothing.
     if kind == "standard":
         p = jnp.ones_like(child_state.mean)
+    elif child_evidence is not None:
+        # A carried evidence is already the right quantity for any child: the
+        # walk seeds a clamped discrete layer with its own p(1-p) and pulls that
+        # up, so no per-kind branch and no fallback are needed here.
+        p = floored * softening
     elif child_kind in ("binary", "categorical"):
         # Clamped discrete child: the curvature of its own likelihood.
         prob = child_state.expected_mean
@@ -347,6 +371,110 @@ def resolve_synaptic_uncertainty_settings(
         increment_scale=increment_scale,
         prior_precision=1.0 / prior_variance,
     )
+
+
+def clamped_layer_evidence(child_state: LayerState, child_kind: str) -> jnp.ndarray:
+    r"""Seed the evidence walk at the layer the data are clamped to.
+
+    A **binary or categorical** layer contributes the exact, label-free curvature
+    of its own likelihood, :math:`\xi_a = \hat{p}_a(1 - \hat{p}_a)`: the diagonal
+    of :math:`\operatorname{diag}(\mathbf{p}) - \mathbf{p}\mathbf{p}^\top`, which
+    is the Hessian of the categorical log-likelihood with respect to the logits.
+    No observed label enters it, so it is the model's own expected curvature
+    rather than one built from the errors that happened to occur.
+
+    A **continuous** layer contributes its own precision, which for a Gaussian
+    likelihood is that same curvature: the second derivative of
+    :math:`-\log \mathcal{N}(y; \mu, 1/\pi)` with respect to :math:`\mu` is
+    :math:`\pi`, whatever the residual. Nothing is approximated. What differs is
+    that the value is a *constant*, and two things follow from that. It varies
+    neither across units nor across samples, so unlike the discrete seed it says
+    nothing about which outputs the data constrain hardest, and every per-weight
+    difference the walk produces above such a layer comes from the activations
+    and the weight pullback alone. And wherever the precision expresses "this
+    layer is observed" rather than a modelled observation noise, its value is
+    arbitrary; since the seed multiplies through the whole chain, it then fixes
+    the scale of every accumulated weight precision above it, which trades
+    against the prior precision.
+
+    Parameters
+    ----------
+    child_state :
+        State of the clamped layer, after the update sweep.
+    child_kind :
+        ``"binary"``, ``"categorical"``, or anything else for a continuous layer.
+
+    Returns
+    -------
+    jnp.ndarray
+        The evidence precision at each node of the clamped layer.
+    """
+    if child_kind in ("binary", "categorical"):
+        prob = child_state.expected_mean
+        evidence = prob * (1.0 - prob)
+    else:
+        evidence = child_state.precision
+    return jnp.where(jnp.isfinite(evidence), evidence, 0.0)
+
+
+def evidence_pullback(
+    parent_state: LayerState,
+    child_evidence: jnp.ndarray,
+    weights: jnp.ndarray,
+    coupling_fn: Callable,
+    parent_has_constant: bool = False,
+) -> jnp.ndarray:
+    r"""Carry the evidence precision up one layer, by the squared-coupling recursion.
+
+    A Gaussian likelihood pulled back through a linear map of coefficient
+    :math:`c` has its precision multiplied by :math:`c^2`; children are
+    conditionally independent given the parent, so their pulled-back precisions
+    add:
+
+    .. math::
+
+        \xi_i = g'(\hat\mu_i)^2 \sum_a W_{ai}^2\, \tilde\xi_a
+
+    This is the upward mirror of the downward variance bleed-through, and
+    computationally it is curvature backpropagation: per sample,
+    :math:`\tilde\xi_a h_i^2` is the Gauss-Newton diagonal of the global loss
+    with respect to :math:`W_{ai}`, under the same diagonal treatment (cross
+    terms between different parents of one child are dropped).
+
+    Computed from the evidence carried in the walk rather than recovered as
+    :math:`\pi_a - \tilde\pi_a` from the filter's cache. The two agree in exact
+    arithmetic, but the difference of two large nearly-equal precisions loses
+    every significant digit once a layer's precision has accumulated, whereas a
+    carried quantity does not.
+
+    Parameters
+    ----------
+    parent_state :
+        State of the layer the evidence is being carried up to.
+    child_evidence :
+        Evidence precision at each node of the layer below, shape
+        ``(n_children,)``.
+    weights :
+        The matrix connecting them, shape ``(n_children, n_parents[+1])``. A bias
+        column is dropped: a constant input node is not a parent whose belief the
+        evidence can be about.
+    coupling_fn :
+        Coupling applied to parent means, differentiated at the parent's expected
+        mean.
+    parent_has_constant :
+        Whether *weights* carries that trailing bias column.
+
+    Returns
+    -------
+    jnp.ndarray
+        The evidence precision at each node of the parent layer, shape
+        ``(n_parents,)``.
+    """
+    if parent_has_constant:
+        weights = weights[..., :-1]
+    coupling_prime = vmap(jgrad(coupling_fn))(parent_state.expected_mean)
+    pulled = jnp.matmul(weights.T**2, child_evidence) * coupling_prime**2
+    return jnp.where(jnp.isfinite(pulled), jnp.maximum(pulled, 0.0), 0.0)
 
 
 def vectorized_synaptic_uncertainty_update(

--- a/pyhgf/utils/vectorized_belief_propagation.py
+++ b/pyhgf/utils/vectorized_belief_propagation.py
@@ -38,6 +38,8 @@ from pyhgf.updates.vectorized.continuous import (
 )
 from pyhgf.updates.vectorized.learning import (
     SynapticUncertaintySettings,
+    clamped_layer_evidence,
+    evidence_pullback,
     learning_weights_vectorized,
     vectorized_synaptic_uncertainty_update,
 )
@@ -503,8 +505,14 @@ def _bottomup_posterior_pe(
 # ---------------------------------------------------------------------------
 
 
-def _layer_weight_op(parent: Layer, child_elem, learning_kind: str):
-    """Learning factors for a ``Layer`` parent and its child."""
+def _layer_weight_op(
+    parent: Layer, child_elem, learning_kind: str, child_evidence=None
+):
+    """Learning factors for a ``Layer`` parent and its child.
+
+    *child_evidence* is passed only by the evidence walk; ``None`` leaves
+    ``learning_weights_vectorized`` to recover the evidence from the cache.
+    """
     child_state, child_kind, _ = _child_view(child_elem)
     return learning_weights_vectorized(
         parent_state=parent.state,
@@ -513,16 +521,31 @@ def _layer_weight_op(parent: Layer, child_elem, learning_kind: str):
         kind=learning_kind,
         parent_has_constant=parent.add_constant_input,
         child_kind=child_kind,
+        child_evidence=child_evidence,
     )
 
 
-def _stack_weight_op(stack: LayerStack, child_elem, learning_kind: str):
-    """Learning factors for every slice of a ``LayerStack``.
+def _stack_weight_op(stack: LayerStack, child_elem, learning_kind: str, evidence=None):
+    """Learning factors for every slice of a ``LayerStack``, and the evidence above it.
 
     The child of slice 0 is the layer below the stack (``child_elem``); the child of
     slice k>0 is slice k-1 within the stack. Pre-pend the external child's state to the
     stack's slices ``0 .. N-2`` along axis 0 to form the ``(N, ...)`` child slots, then
     ``vmap`` over the N parent slices (``stack.state``) and the child slots.
+
+    The evidence walk cannot be vectorised the same way, because slice k's evidence is
+    a function of slice k-1's: it is a recursion, not a map. It is carried by a
+    ``scan`` that emits, per slice, the evidence *arriving* at that slice from below,
+    which is exactly what the slice's own increment needs; the scan's final carry is
+    the evidence leaving the top of the stack, for the element above it.
+
+    *evidence* is ``None`` for the learning kinds that never read the importance
+    factor; the walk is then skipped and the evidence above the stack is ``None`` too.
+
+    Returns
+    -------
+    tuple
+        The stacked factor triple, and the evidence at the top of the stack.
     """
     child_state, _, _ = _child_view(child_elem)
     child_state = _match_child_vol_structure(child_state, stack.has_volatility_parent)
@@ -533,7 +556,28 @@ def _stack_weight_op(stack: LayerStack, child_elem, learning_kind: str):
         stack.state,
     )
 
-    def per_slice(parent_state, child_state_for_slice):
+    def carry(evidence_below, slice_data):
+        slice_state, slice_weights = slice_data
+        above = evidence_pullback(
+            parent_state=slice_state,
+            child_evidence=evidence_below,
+            weights=slice_weights,
+            coupling_fn=stack.coupling_fn,
+            parent_has_constant=stack.add_constant_input,
+        )
+        return above, evidence_below
+
+    if evidence is None:
+        evidence_out = None
+        per_slice_evidence = jnp.zeros(stack.state.mean.shape)
+    else:
+        evidence_out, per_slice_evidence = jax.lax.scan(
+            carry, evidence, (stack.state, stack.weights_mean)
+        )
+
+    walking = evidence is not None
+
+    def per_slice(parent_state, child_state_for_slice, child_evidence):
         return learning_weights_vectorized(
             parent_state=parent_state,
             child_state=child_state_for_slice,
@@ -541,9 +585,11 @@ def _stack_weight_op(stack: LayerStack, child_elem, learning_kind: str):
             kind=learning_kind,
             parent_has_constant=stack.add_constant_input,
             child_kind="continuous",
+            child_evidence=child_evidence if walking else None,
         )
 
-    return jax.vmap(per_slice)(stack.state, child_states)
+    factors = jax.vmap(per_slice)(stack.state, child_states, per_slice_evidence)
+    return (factors, evidence_out) if walking else factors
 
 
 def _weight_op(parent_elem, child_elem, learning_kind: str):
@@ -975,7 +1021,7 @@ def input_prediction_error(network: Network) -> jnp.ndarray:
 
 
 def _weight_quantities(network: Network, learning_kind: str) -> tuple:
-    """Per-element weight-learning factors, without applying them.
+    r"""Per-element weight-learning factors, without applying them.
 
     Must run *after* :func:`_update_sweep`, so the per-layer states already carry their
     prediction errors / posteriors. Returns one entry per element, matched 1:1 to
@@ -983,12 +1029,58 @@ def _weight_quantities(network: Network, learning_kind: str) -> tuple:
     weights); each entry is the factor tuple of
     :func:`pyhgf.updates.vectorized.learning.learning_weights_vectorized`.
     Assemble them with :func:`_gradient_matrix` and :func:`_importance_pair`.
+
+    Under ``learning_kind="synaptic_uncertainty"`` the importance increment's
+    child-side factor is the evidence precision, and this walks it up the stack in its
+    own quantity: seeded at the clamped layer by
+    :func:`~pyhgf.updates.vectorized.learning.clamped_layer_evidence` and raised one
+    element at a time by
+    :func:`~pyhgf.updates.vectorized.learning.evidence_pullback`. This loop runs bottom
+    to top already, which is the order the recursion needs, so the walk costs one
+    matrix product per element and no extra sweep.
+
+    The evidence is *carried* rather than recovered from the filter's cache as
+    :math:`\pi_a - \tilde\pi_a`. The two agree in exact arithmetic only where the
+    filter's own chain is seeded with the clamped layer's likelihood curvature, which
+    it is not: a clamped categorical layer enters that chain at unit precision, because
+    that convention is what makes the message it routes exact cross-entropy
+    backpropagation. One variable cannot serve both roles, so the curvature gets its
+    own. Carrying it also removes a subtraction of two large nearly-equal precisions,
+    which loses every significant digit once a layer's precision has accumulated.
+
+    The other learning kinds never read the importance factor, so they skip the walk.
     """
     elements = network.layers
-    return (None,) + tuple(
-        _weight_op(elements[i], elements[i - 1], learning_kind)
-        for i in range(1, len(elements))
-    )
+    if learning_kind != "synaptic_uncertainty":
+        return (None,) + tuple(
+            _weight_op(elements[i], elements[i - 1], learning_kind)
+            for i in range(1, len(elements))
+        )
+
+    child_state, child_kind, _ = _child_view(elements[0])
+    evidence = clamped_layer_evidence(child_state, child_kind)
+
+    factors: list = [None]
+    for i in range(1, len(elements)):
+        parent = elements[i]
+        if isinstance(parent, LayerStack):
+            stack_factors, evidence = _stack_weight_op(
+                parent, elements[i - 1], learning_kind, evidence
+            )
+            factors.append(stack_factors)
+            continue
+        factors.append(
+            _layer_weight_op(parent, elements[i - 1], learning_kind, evidence)
+        )
+        if i + 1 < len(elements):
+            evidence = evidence_pullback(
+                parent_state=parent.state,
+                child_evidence=evidence,
+                weights=parent.weights_mean,
+                coupling_fn=parent.coupling_fn,
+                parent_has_constant=parent.add_constant_input,
+            )
+    return tuple(factors)
 
 
 def _gradient_matrix(factors) -> Optional[jnp.ndarray]:

--- a/tests/test_weight_belief.py
+++ b/tests/test_weight_belief.py
@@ -107,6 +107,40 @@ def test_effective_evidence_precision():
     )
     assert np.all(np.asarray(xi_tilde(clipped)) >= 0.0)
 
+    # The same floor also guards the softening denominator, 1 / (1 + omega * xi).
+    # Left unfloored, a negative evidence would inflate the gradient instead of
+    # attenuating it, and a large enough one would flip its sign.
+    clipped_noisy = dataclasses.replace(
+        clipped,
+        mean=jnp.array([1.0, -2.0, 0.5]),
+        expected_mean=jnp.zeros(n),
+        effective_precision=0.25 * jnp.array([4.0, 4.0, 4.0]),
+    )
+    u_ev, _, _ = learning_weights_vectorized(
+        parent, clipped_noisy, lambda m: m, kind="synaptic_uncertainty"
+    )
+    u_pw, _, _ = learning_weights_vectorized(
+        parent, clipped_noisy, lambda m: m, kind="precision_weighted"
+    )
+    np.testing.assert_allclose(u_ev, u_pw, rtol=1e-6)
+
+    # A supplied evidence replaces the cached difference and is softened by the
+    # same process noise. Asserted here because the networks the walk is
+    # exercised on end to end carry no volatility parent, so their omega is
+    # identically zero and the softening is inert in them.
+    noisy = dataclasses.replace(
+        base,
+        expected_precision=jnp.array([1.0, 2.0, 0.5]),
+        precision=jnp.array([5.0, 6.0, 2.5]),
+        effective_precision=0.25 * jnp.array([1.0, 2.0, 0.5]),
+    )
+    carried = jnp.array([2.0, 8.0, 1.0])
+    _, _, p = learning_weights_vectorized(
+        parent, noisy, lambda m: m, child_evidence=carried
+    )
+    carried_np = np.asarray(carried)
+    np.testing.assert_allclose(p, carried_np / (1.0 + 0.25 * carried_np), rtol=1e-6)
+
 
 def _step(weights, precision_delta, gradient, importance, **kwargs):
     """One belief step, returning ``(update, new_delta)``.
@@ -526,3 +560,126 @@ def test_install_weight_belief_is_explicit_and_idempotent():
 
     with pytest.raises(ValueError, match="hold no weight matrix"):
         net.install_weight_belief(layers=[0])
+
+
+def test_evidence_walk_curvature():
+    """The walk's increment is the Gauss-Newton diagonal; the sweep's is inflated.
+
+    The importance increment is meant to be the curvature the data impose on a
+    weight. Recovering the evidence from the filter's cache as
+    ``precision - expected_precision`` does not deliver that above the observed
+    layer, because the chain it is read from is seeded with the clamped layer's
+    unit precision rather than with the categorical curvature ``p(1 - p)``: the
+    interior increment comes out several times too large. Carrying the evidence
+    instead reproduces the autodiff Gauss-Newton diagonal.
+    """
+    from jax.nn import leaky_relu
+
+    from pyhgf.utils.vectorized_belief_propagation import (
+        _importance_pair,
+        _prediction_sweep,
+        _update_sweep,
+        _weight_quantities,
+    )
+
+    def build():
+        net = (
+            DeepNetwork(coupling_fn=leaky_relu)
+            .add_layer(size=3, kind="categorical", volatility_parent=False)
+            .add_layer(size=8, volatility_parent=False)
+            .add_layer(size=2, volatility_parent=False)
+        )
+        return net.weight_initialisation("he", key=jax.random.key(0))
+
+    net = build()
+    x = jnp.asarray([0.7, -0.4])
+    y = jnp.asarray([0.0, 1.0, 0.0])
+
+    def increments(learning_kind):
+        swept = _update_sweep(_prediction_sweep(net.state, x), y)
+        factors = _weight_quantities(swept, learning_kind)
+        pairs = [_importance_pair(f) for f in factors[1:]]
+        return [np.asarray(p[:, None] * h2[None, :]) for p, h2 in pairs]
+
+    # Ground truth: J^T (diag(p) - p p^T) J on the diagonal, by autodiff over the
+    # same weights, with the constant input node written out explicitly.
+    weights = [jnp.asarray(w) for w in net.state.weights]
+
+    def logits(params, features):
+        h = jnp.concatenate([leaky_relu(features), jnp.ones(1)])
+        h = leaky_relu(params[1] @ h)
+        return params[0] @ jnp.concatenate([h, jnp.ones(1)])
+
+    probs = jax.nn.softmax(logits(weights, x))
+    hessian = jnp.diag(probs) - jnp.outer(probs, probs)
+    jacobian = jax.jacobian(logits)(weights, x)
+    exact = [np.asarray(jnp.einsum("cij,cd,dij->ij", j, hessian, j)) for j in jacobian]
+
+    def median_ratio(got, want):
+        live = want > 1e-12
+        return float(np.median(got[live] / want[live]))
+
+    walked = increments("synaptic_uncertainty")
+
+    # Both matrices reproduce the Gauss-Newton diagonal: the head because its
+    # child is the clamped layer whose curvature seeds the walk, and the one
+    # above it because the walk carries that seed up rather than re-reading a
+    # chain the filter seeded at unit precision.
+    for got, want in zip(walked, exact):
+        assert median_ratio(got, want) == pytest.approx(1.0, abs=0.2)
+
+
+def test_evidence_walk_through_a_layer_stack():
+    """The walk carries the evidence through a stack's slices, by scan.
+
+    Slice k's evidence is a function of slice k-1's, so it cannot be mapped over the
+    slices the way the factors are; the scan that carries it must leave the stack with
+    the same evidence a chain of plain layers would.
+    """
+    from pyhgf.utils.vectorized_belief_propagation import (
+        _prediction_sweep,
+        _update_sweep,
+        _weight_quantities,
+    )
+
+    def build(stacked: bool):
+        net = (
+            DeepNetwork(coupling_fn=jax.nn.leaky_relu)
+            .add_layer(size=3, kind="categorical", volatility_parent=False)
+            .add_layer(size=6, add_constant_input=True, volatility_parent=False)
+        )
+        sizes = [6] * 5
+        if stacked:
+            net = net.add_layer_stack(
+                layer_sizes=sizes, add_constant_input=True, volatility_parent=False
+            )
+        else:
+            for size in sizes:
+                net = net.add_layer(
+                    size=size, add_constant_input=True, volatility_parent=False
+                )
+        return net.add_layer(size=2, add_constant_input=False).weight_initialisation(
+            "he", key=jax.random.key(3)
+        )
+
+    stacked, plain = build(True), build(False)
+    assert any(type(e).__name__ == "LayerStack" for e in stacked.state.layers)
+    assert not any(type(e).__name__ == "LayerStack" for e in plain.state.layers)
+
+    x = jnp.asarray([0.6, -0.2])
+    y = jnp.asarray([0.0, 0.0, 1.0])
+
+    def top_factors(net):
+        swept = _update_sweep(_prediction_sweep(net.state, x), y)
+        return _weight_quantities(swept, "synaptic_uncertainty")[-1]
+
+    # The element above the stack sees the evidence the scan carried out of it,
+    # so its importance factor is the check that the recursion was not mapped.
+    got, want = np.asarray(top_factors(stacked)[2]), np.asarray(top_factors(plain)[2])
+
+    # Compared as a ratio, and with the scale asserted first. Six pullbacks leave
+    # the evidence around 1e-9, so any absolute tolerance loose enough to look
+    # reasonable is orders of magnitude larger than the quantity itself and the
+    # comparison passes whatever the stack did.
+    assert np.all(want > 0.0)
+    np.testing.assert_allclose(got / want, 1.0, rtol=1e-4)


### PR DESCRIPTION
The weight-belief rule recovered its evidence from the filter's precision chain as `π − π̃`, which was wrong twice over: that chain enters a clamped categorical layer at unit precision rather than the exact softmax curvature `p(1−p)`, inflating interior
curvature and worsening as the model grows confident; and the difference of two accumulated float32 precisions had lost every significant digit. 

The evidence is now carried in its own quantity, seeded by `clamped_layer_evidence` and raised by `evidence_pullback` along the bottom-to-top pass `_weight_quantities` already makes, with a `scan` carrying it through a `LayerStack`.